### PR TITLE
Update naming rules of EventBridge event rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/cicd
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/cicd/README.md
+++ b/cicd/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/cicd
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/cicd/README_JP.md
+++ b/cicd/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/cicd
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/cicd/README_JP.md
+++ b/cicd/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/cicd
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/cicd/templates/codebuild.yaml
+++ b/cicd/templates/codebuild.yaml
@@ -63,7 +63,7 @@ Resources:
   # Nested Stack
   SNSForAlert:
     Condition: CreateSNSForAlert
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
@@ -79,7 +79,7 @@ Resources:
         createdby: !Ref TagValue
   SNSForDeployment:
     Condition: CreateSNSForDeployment
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
@@ -311,7 +311,7 @@ Resources:
       RetentionInDays: 60
   # CloudWatch Alarm
   AlarmCodeBuildForMasterBranch:
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
@@ -331,7 +331,7 @@ Resources:
       Tags:
         createdby: !Ref TagValue
   AlarmCodeBuildForTargetBranch:
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
@@ -351,7 +351,7 @@ Resources:
       Tags:
         createdby: !Ref TagValue
   AlarmCodeBuildForTags:
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild

--- a/cicd/templates/codebuild.yaml
+++ b/cicd/templates/codebuild.yaml
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -83,7 +83,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -315,7 +315,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -335,7 +335,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -355,7 +355,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -98,7 +98,7 @@ Resources:
   # Nested Stack
   SNSForAlert:
     Condition: CreateSNSForAlert
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
@@ -114,7 +114,7 @@ Resources:
         createdby: !Ref TagValue
   SNSForDeployment:
     Condition: CreateSNSForDeployment
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
@@ -788,7 +788,7 @@ Resources:
           Value: !Ref TagValue
   # CloudWatch Alarm
   AlarmCodeBuildForSAM:
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
@@ -808,7 +808,7 @@ Resources:
       Tags:
         createdby: !Ref TagValue
   AlarmCodeBuildForNestedStack:
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
@@ -828,7 +828,7 @@ Resources:
       Tags:
         createdby: !Ref TagValue
   AlarmEventsForCodePipeline:
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -102,7 +102,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -118,7 +118,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -792,7 +792,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -812,7 +812,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -832,7 +832,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/global/README.md
+++ b/global/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/global
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/global/README.md
+++ b/global/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/global
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/global/README_JP.md
+++ b/global/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/global
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/global/README_JP.md
+++ b/global/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/global
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -56,7 +56,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
@@ -112,7 +112,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
@@ -164,7 +164,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
@@ -214,7 +214,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
@@ -265,7 +265,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
@@ -316,7 +316,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
@@ -373,7 +373,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
@@ -432,7 +432,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
@@ -483,7 +483,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
@@ -533,7 +533,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/monitoring
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -60,7 +60,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -116,7 +116,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -168,7 +168,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -218,7 +218,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -269,7 +269,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -320,7 +320,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -377,7 +377,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -436,7 +436,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -487,7 +487,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -537,7 +537,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/monitoring
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/monitoring
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -58,7 +58,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -114,7 +114,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -166,7 +166,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -216,7 +216,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -267,7 +267,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -318,7 +318,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -375,7 +375,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -434,7 +434,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -485,7 +485,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 
@@ -535,7 +535,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.7
+    SemanticVersion: 1.0.8
   NotificationARNs: 
     - String
   Parameters: 

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -54,7 +54,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
@@ -110,7 +110,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
@@ -162,7 +162,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
@@ -212,7 +212,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
@@ -263,7 +263,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
@@ -314,7 +314,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
@@ -371,7 +371,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
@@ -430,7 +430,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
@@ -481,7 +481,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
@@ -531,7 +531,7 @@ Properties:
 ```
 
 ```yaml
-Type: AWS::Serverless::Application
+Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/monitoring
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/notification/README.md
+++ b/notification/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/notification
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/notification/README.md
+++ b/notification/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/notification
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/notification/README_JP.md
+++ b/notification/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/notification
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates) 
  

--- a/notification/README_JP.md
+++ b/notification/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/notification
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates) 
  

--- a/notification/sam-app/events.yaml
+++ b/notification/sam-app/events.yaml
@@ -74,7 +74,7 @@ Resources:
           - aws.events
         detail-type: 
           - Scheduled Event
-      Name: ScheduledEvents
+      Name: !Sub ${AWS::StackName}-ScheduledEvents
       State: !Ref ScheduledEventsRule
       Targets:
         - Arn: !Ref SNSForAlertArn
@@ -91,7 +91,7 @@ Resources:
           - EBS Snapshot Notification
           - EBS Multi-Volume Snapshots Completion Status
           - EBS Fast Snapshot Restore State-change Notification
-      Name: EBS
+      Name: !Sub ${AWS::StackName}-EBS
       State: !Ref EBSEventsRule
       Targets:
         - Arn: !Ref SNSForAlertArn
@@ -110,7 +110,7 @@ Resources:
           - EC2 Instance-terminate Lifecycle Action
           - EC2 Instance Terminate Successful
           - EC2 Instance Terminate Unsuccessful
-      Name: AutoScaling
+      Name: !Sub ${AWS::StackName}-AutoScaling
       State: !Ref AutoScalingEventsRule
       Targets:
         - Arn: !Ref SNSForAlertArn
@@ -124,7 +124,7 @@ Resources:
           - aws.ec2
         detail-type: 
           - EC2 Instance State-change Notification
-      Name: EC2
+      Name: !Sub ${AWS::StackName}-EC2
       State: !Ref EC2EventsRule
       Targets:
         - Arn: !Ref SNSForAlertArn
@@ -140,7 +140,7 @@ Resources:
           - KMS CMK Rotations
           - KMS Imported Key Material Expiration
           - KMS CMK Deletion
-      Name: KMS
+      Name: !Sub ${AWS::StackName}-KMS
       State: !Ref KMSEventsRule
       Targets:
         - Arn: !Ref SNSForAlertArn
@@ -154,7 +154,7 @@ Resources:
           - aws.signin
         detail-type: 
           - AWS Console Sign In via CloudTrail
-      Name: ManagementConsole
+      Name: !Sub ${AWS::StackName}-ManagementConsole
       State: !Ref ManagementConsoleEventsRule
       Targets:
         - Arn: !Ref SNSForAlertArn
@@ -182,7 +182,7 @@ Resources:
           - aws.trustedadvisor
         detail-type: 
           - Trusted Advisor Check Item Refresh Notification
-      Name: TrustedAdvisor
+      Name: !Sub ${AWS::StackName}-TrustedAdvisor
       State: !Ref TrustedAdvisorEventsRule
       Targets:
         - Arn: !Ref SNSForAlertArn

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -122,7 +122,7 @@ Resources:
   # Nested Stack
   SNSForAlert:
     Condition: CreateSNSForAlert
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
@@ -138,7 +138,7 @@ Resources:
         createdby: !Ref TagValue
   SNSForDeployment:
     Condition: CreateSNSForDeployment
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
@@ -148,7 +148,7 @@ Resources:
       Tags:
         createdby: !Ref TagValue
   EventsRule:
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/eventbridge-rules
@@ -473,7 +473,7 @@ Resources:
   # Chatbot
   ChatbotForDeployment:
     Condition: CreateChatbotForDeployment
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location: https://s3.amazonaws.com/eijikominami/aws-cloudformation-templates/notification/chatbot.yaml
       NotificationARNs:
@@ -494,7 +494,7 @@ Resources:
         createdby: !Ref TagValue
   ChatbotForAlert:
     Condition: CreateChatbot
-    Type: AWS::Serverless::Application
+    Type: 'AWS::Serverless::Application'
     Properties:
       Location: https://s3.amazonaws.com/eijikominami/aws-cloudformation-templates/notification/chatbot.yaml
       NotificationARNs:
@@ -513,6 +513,12 @@ Resources:
           - !Ref SNSForAlertArn
       Tags:
         createdby: !Ref TagValue
+  # CloudWatch Dashboard
+  Dashboard:
+    Type: 'AWS::CloudWatch::Dashboard'
+    Properties:
+      DashboardName: !Sub ${AWS::StackName}-${AWS::Region}
+      DashboardBody: !Sub '{"widgets": [{"type": "text","x": 0,"y": 0,"width": 24,"height": 2,"properties": {"markdown": "\n# Lambda sendNotificationToSlack()\n\nCloudWatch アラームの内容をSlackに送信します\n"}},{"type": "metric","x": 12,"y": 2,"width": 12,"height": 9,"properties": {"metrics": [[ "AWS/Lambda", "Errors", "FunctionName", "sendNotificationToSlack", "Resource", "sendNotificationToSlack", { "color": "#d62728" } ],[ ".", "Throttles", ".", ".", ".", "." ],[ ".", "ConcurrentExecutions", ".", ".", ".", "." ],[ ".", "Invocations", ".", ".", ".", ".", { "color": "#1f77b4" } ]],"view": "timeSeries","stacked": false,"region": "${AWS::Region}","stat": "Sum","period": 60,"title": "Count"}},{"type": "metric","x": 0,"y": 5,"width": 6,"height": 3,"properties": {"title": "ClientError","annotations": {"alarms": ["arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:Warning-${AWS::StackName}-Lambda-sendNotificationToSlack-ClientError"]},"view": "timeSeries","stacked": false}},{"type": "metric","x": 0,"y": 8,"width": 6,"height": 3,"properties": {"title": "TypeError","annotations": {"alarms": ["arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:Warning-${AWS::StackName}-Lambda-sendNotificationToSlack-TypeError"]},"view": "timeSeries","stacked": false}},{"type": "metric","x": 6,"y": 5,"width": 6,"height": 3,"properties": {"title": "Throttles","annotations": {"alarms": ["arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:Warning-${AWS::StackName}-Lambda-sendNotificationToSlack-Throttles"]},"view": "timeSeries","stacked": false}},{"type": "metric","x": 0,"y": 2,"width": 12,"height": 3,"properties": {"title": "Duration","annotations": {"alarms": ["arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:Warning-${AWS::StackName}-Lambda-sendNotificationToSlack-Timeout-Will-Occur"]},"view": "timeSeries","stacked": false}},{"type": "metric","x": 6,"y": 8,"width": 6,"height": 3,"properties": {"title": "Errors","annotations": {"alarms": ["arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:Warning-${AWS::StackName}-Lambda-sendNotificationToSlack-Errors"]},"view": "timeSeries","stacked": false}},{"type": "log","x": 0,"y": 11,"width": 12,"height": 3,"properties": {"query": "SOURCE ''/aws/lambda/sendNotificationToSlack'' | fields @message, @timestamp | filter @message like /(?i)ERROR/ | sort @timestamp desc | limit 20","region": "${AWS::Region}","stacked": false,"view": "table","title": "Error"}},{"type": "log","x": 12,"y": 11,"width": 12,"height": 3,"properties": {"query": "SOURCE ''/aws/lambda/sendNotificationToSlack'' | fields records, @timestamp | filter records>0 | sort @timestamp desc | limit 60","region": "${AWS::Region}","stacked": false,"title": "Records","view": "table"}}]}'
 
 Outputs:
   LambdaSendNotificationToSlackARN:

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -126,7 +126,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -142,7 +142,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -152,7 +152,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/eventbridge-rules
-        SemanticVersion: 1.0.7
+        SemanticVersion: 1.0.8
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/security-config-rules/README.md
+++ b/security-config-rules/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/security-config-rules
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/security-config-rules/README.md
+++ b/security-config-rules/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/security-config-rules
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/security-config-rules/README_JP.md
+++ b/security-config-rules/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/security-config-rules
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/security-config-rules/README_JP.md
+++ b/security-config-rules/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/security-config-rules
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/security/README.md
+++ b/security/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/security
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates) 
 

--- a/security/README.md
+++ b/security/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/security
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates) 
 

--- a/security/README_JP.md
+++ b/security/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/security
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/security/README_JP.md
+++ b/security/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/security
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/static-website-hosting-with-ssl/README.md
+++ b/static-website-hosting-with-ssl/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/static-website-hosting-with-ssl
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/static-website-hosting-with-ssl/README.md
+++ b/static-website-hosting-with-ssl/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/static-website-hosting-with-ssl
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/static-website-hosting-with-ssl/README_JP.md
+++ b/static-website-hosting-with-ssl/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/static-website-hosting-with-ssl
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/static-website-hosting-with-ssl/README_JP.md
+++ b/static-website-hosting-with-ssl/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/static-website-hosting-with-ssl
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
 

--- a/web-servers/README.md
+++ b/web-servers/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/web-servers
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/web-servers/README.md
+++ b/web-servers/README.md
@@ -1,7 +1,7 @@
 English / [**日本語**](README_JP.md)
 
 # AWSCloudFormationTemplates/web-servers
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/web-servers/README_JP.md
+++ b/web-servers/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/web-servers
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiT1o3djE0RFpweWErRDl6SkpwTGsySVJKbWk0ajhreUlEaXAvTHh3ZzdaS2wzNVR5V1hpZkZRRVRtcFIvNncydWdad2w4TG9MRVMzVGFvMlZKY2RNYUowPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik0vOGVWdGFEWTlyYVdDZUwiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  

--- a/web-servers/README_JP.md
+++ b/web-servers/README_JP.md
@@ -1,7 +1,7 @@
 [**English**](README.md) / 日本語
 
 # AWSCloudFormationTemplates/web-servers
-![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoidzhOZGpLeGpGQ1FmTVlkNkxTTGxIWFhMZk5BRXBmR1pVVHhWbWVIdmIzRyttcmw2RUF3YkxTWStMWTVReXJ2UkhhTUFlSitia3REVGFBcTAvR29uZ1pVPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRLV2tpS0lhWDc1aDJpU1AiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiLzdYc1dVbmpHY1IvdnVCK2FrTS85dFhHMytNS2kzdEJ1YnE0MFhlc0ttanVIWWRhL1dBOTltSFZERGtZYWlmdlZnWElXWTBjcjdzSldHT0YyaGkxd01rPSIsIml2UGFyYW1ldGVyU3BlYyI6InF5RTZQQTBEYUNBVUJZU0kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
 ![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
  


### PR DESCRIPTION
**Why is this change necessary?**

+ In case of creating the Notification template in the same region, rule names are duplicate.

**How does it address the issue?**

+ Update naming rules of EventBridge event rules in event.yaml

**What side effects does this change have?**

+ None at this point.