### PR TITLE
Update templates and the build specification file.

### DIFF
--- a/buildspec-upload-artifacts-serverlessrepo.yml
+++ b/buildspec-upload-artifacts-serverlessrepo.yml
@@ -40,7 +40,7 @@ phases:
       - aws s3 cp monitoring/cloudwatch-alarm-about-events.md s3://${BUCKET_NAME}/readme/
       - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-events --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-events.md --region us-east-1
       - aws s3 cp monitoring/cloudwatch-alarm-about-kinesis-data-streams.md s3://${BUCKET_NAME}/readme/
-      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/ --readme-url s3://${BUCKET_NAME}/readme/.md --region us-east-1
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-kinesis-data-streams --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-kinesis-data-streams.md --region us-east-1
       - aws s3 cp monitoring/cloudwatch-alarm-about-lambda.md s3://${BUCKET_NAME}/readme/
       - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-lambda --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-lambda.md --region us-east-1
       - aws s3 cp monitoring/cloudwatch-alarm-about-natgateway.md s3://${BUCKET_NAME}/readme/

--- a/buildspec-upload-artifacts-serverlessrepo.yml
+++ b/buildspec-upload-artifacts-serverlessrepo.yml
@@ -1,5 +1,10 @@
 version: 0.2
 
+env:
+  variables:
+    SOURCE_CODE_URL: https://github.com/eijikominami/aws-cloudformation-templates
+    APP_ARN_PREFIX: arn:aws:serverlessrepo:us-east-1:172664222583:applications
+
 phases:
   pre_build:
     commands:
@@ -7,16 +12,44 @@ phases:
       - echo $SEMANTIC_VERSION
   build:
     commands:
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/apigateway.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/codebuild.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/dynamodb-throttle.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/dynamodb.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2 --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/ec2.yaml --region us-east-1  
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/events.yaml --region us-east-1    
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis-data-streams --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/kinesis.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/lambda.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/natgateway.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/monitoring/sns.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/notification/sns.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/eventbridge-rules --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/notification/events.yaml --region us-east-1
-      - aws serverlessrepo create-application-version --source-code-url https://github.com/eijikominami/aws-cloudformation-templates --application-id arn:aws:serverlessrepo:us-east-1:172664222583:applications/delete-resources-without-required-tags --semantic-version ${SEMANTIC_VERSION} --template-url https://${BUCKET_NAME}.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/security-config-rules/packaged.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-apigateway --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/apigateway.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-codebuild --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/codebuild.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-dynamodb-throttle --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/dynamodb-throttle.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-dynamodb --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/dynamodb.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-ec2 --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/ec2.yaml --region us-east-1  
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-events --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/events.yaml --region us-east-1    
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-kinesis-data-streams --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/kinesis.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-lambda --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/lambda.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-natgateway --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/natgateway.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-sns --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/monitoring/sns.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/sns-topic --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/notification/sns.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/eventbridge-rules --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/notification/events.yaml --region us-east-1
+      - aws serverlessrepo create-application-version --source-code-url ${SOURCE_CODE_URL} --application-id ${APP_ARN_PREFIX}/delete-resources-without-required-tags --semantic-version ${SEMANTIC_VERSION} --template-url s3://${BUCKET_NAME}/aws-cloudformation-templates/security-config-rules/packaged.yaml --region us-east-1
+  post_build:
+    commands:
+      - aws s3 cp monitoring/cloudwatch-alarm-about-apigateway.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-apigateway --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-apigateway.md --region us-east-1
+      - aws s3 cp monitoring/cloudwatch-alarm-about-codebuild.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-codebuild --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-codebuild.md --region us-east-1
+      - aws s3 cp monitoring/cloudwatch-alarm-about-dynamodb-throttle.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-dynamodb-throttle --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-dynamodb-throttle.md --region us-east-1
+      - aws s3 cp monitoring/cloudwatch-alarm-about-dynamodb.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-dynamodb --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-dynamodb.md --region us-east-1
+      - aws s3 cp monitoring/cloudwatch-alarm-about-ec2.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-ec2 --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-ec2.md --region us-east-1
+      - aws s3 cp monitoring/cloudwatch-alarm-about-events.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-events --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-events.md --region us-east-1
+      - aws s3 cp monitoring/cloudwatch-alarm-about-kinesis-data-streams.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/ --readme-url s3://${BUCKET_NAME}/readme/.md --region us-east-1
+      - aws s3 cp monitoring/cloudwatch-alarm-about-lambda.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-lambda --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-lambda.md --region us-east-1
+      - aws s3 cp monitoring/cloudwatch-alarm-about-natgateway.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-natgateway --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-natgateway.md --region us-east-1
+      - aws s3 cp monitoring/cloudwatch-alarm-about-sns.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/cloudwatch-alarm-about-sns --readme-url s3://${BUCKET_NAME}/readme/cloudwatch-alarm-about-sns.md --region us-east-1
+      - aws s3 cp notification/eventbridge-rules.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/eventbridge-rules --readme-url s3://${BUCKET_NAME}/readme/eventbridge-rules.md --region us-east-1
+      - aws s3 cp notification/sns-topic.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/sns-topic --readme-url s3://${BUCKET_NAME}/readme/sns-topic.md --region us-east-1
+      - aws s3 cp security-config-rules/delete-resources-without-required-tags.md s3://${BUCKET_NAME}/readme/
+      - aws serverlessrepo update-application --application-id ${APP_ARN_PREFIX}/delete-resources-without-required-tags --readme-url s3://${BUCKET_NAME}/readme/delete-resources-without-required-tags.md --region us-east-1

--- a/cicd/templates/codebuild.yaml
+++ b/cicd/templates/codebuild.yaml
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -83,7 +83,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -320,7 +320,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -340,7 +340,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -360,7 +360,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cicd/templates/codebuild.yaml
+++ b/cicd/templates/codebuild.yaml
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -83,7 +83,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -132,6 +132,7 @@ Resources:
               # Required for creating the new application version in AWS Serverless Application Repository
               - Action:
                   - serverlessrepo:CreateApplicationVersion
+                  - serverlessrepo:UpdateApplication
                 Resource: "*"
                 Effect: Allow
               # Required for uploading artifacts to S3 buckets
@@ -319,7 +320,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -339,7 +340,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -359,7 +360,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -102,7 +102,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -118,7 +118,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -792,7 +792,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -812,7 +812,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -832,7 +832,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -102,7 +102,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -118,7 +118,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -792,7 +792,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -812,7 +812,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -832,7 +832,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -60,7 +60,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -116,7 +116,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -168,7 +168,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -218,7 +218,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -269,7 +269,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -320,7 +320,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -377,7 +377,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -436,7 +436,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -487,7 +487,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -537,7 +537,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -60,7 +60,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -116,7 +116,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -168,7 +168,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -218,7 +218,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -269,7 +269,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -320,7 +320,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -377,7 +377,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -436,7 +436,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -487,7 +487,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -537,7 +537,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -58,7 +58,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -114,7 +114,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -166,7 +166,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -216,7 +216,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -267,7 +267,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -318,7 +318,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -375,7 +375,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -434,7 +434,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -485,7 +485,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 
@@ -535,7 +535,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
   NotificationARNs: 
     - String
   Parameters: 

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -58,7 +58,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -114,7 +114,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -166,7 +166,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -216,7 +216,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -267,7 +267,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -318,7 +318,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -375,7 +375,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -434,7 +434,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -485,7 +485,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 
@@ -535,7 +535,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.11
+    SemanticVersion: 1.0.13
   NotificationARNs: 
     - String
   Parameters: 

--- a/notification/sam-app/events.yaml
+++ b/notification/sam-app/events.yaml
@@ -173,7 +173,6 @@ Resources:
           - aws.tag
         detail-type: 
           - Tag Change on Resource
-      Name: Tag
       State: !Ref TagEventsRule
       Targets:
         - Arn: !Ref SNSForAlertArn

--- a/notification/sam-app/sendNotificationToSlack/lambda_function.py
+++ b/notification/sam-app/sendNotificationToSlack/lambda_function.py
@@ -113,11 +113,11 @@ def createCloudWatchAlarmMessage(message):
             'text': "%s" % (alarm_description),
             'fields': [
                     {
-                        'title': "名前",
+                        'title': "Alarm Name",
                         'value': "%s" % (alarm_name)
                     },
                     {
-                        'title': "原因",
+                        'title': "Cause",
                         'value': "%s" % (reason)
                     }
                 ]

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -126,7 +126,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -142,7 +142,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -152,7 +152,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/eventbridge-rules
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -126,7 +126,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -142,7 +142,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -152,7 +152,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/eventbridge-rules
-        SemanticVersion: 1.0.10
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -294,7 +294,7 @@ Resources:
         - CreateKMSKey
         - !GetAtt KMSKey.Arn
         - !Ref AWS::NoValue
-      MemorySize: 128
+      MemorySize: 512
       Role: !GetAtt IAMRoleForLambda.Arn
       Timeout: 30
   LogGroupForLambdaSendNotificationToSlack:

--- a/security/templates/template.yaml
+++ b/security/templates/template.yaml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
 Description: AWSCloudFormationTemplates/security sets basic configurations for security.
 
 Parameters:
@@ -160,29 +161,31 @@ Resources:
           Value: !Ref TagValue
   SNSForAlert:
     Condition: CreateSNSForAlert
-    Type: AWS::CloudFormation::Stack
+    Type: 'AWS::Serverless::Application'
     Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
           - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
           - !Ref SNSForDeploymentArn
-      Parameters: 
+      Parameters:
         TopicName: !Sub Alert-createdby-${AWS::StackName}
-      TemplateURL: https://s3.amazonaws.com/eijikominami/aws-cloudformation-templates/notification/sns.yaml
       Tags:
-        - Key: !Ref TagKey
-          Value: !Ref TagValue
+        createdby: !Ref TagValue
   SNSForDeployment:
     Condition: CreateSNSForDeployment
-    Type: AWS::CloudFormation::Stack
+    Type: 'AWS::Serverless::Application'
     Properties:
-      Parameters: 
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 1.0.11
+      Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
-      TemplateURL: https://s3.amazonaws.com/eijikominami/aws-cloudformation-templates/notification/sns.yaml
       Tags:
-        - Key: !Ref TagKey
-          Value: !Ref TagValue
+        createdby: !Ref TagValue
   # S3
   S3ForAccessLog:
     Type: 'AWS::S3::Bucket'

--- a/security/templates/template.yaml
+++ b/security/templates/template.yaml
@@ -165,7 +165,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -181,7 +181,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/static-website-hosting-with-ssl/templates/template.yaml
+++ b/static-website-hosting-with-ssl/templates/template.yaml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
 Description: AWSCloudFormationTemplates/static-web-hosting creates environment of static web hosting.
 
 Parameters:
@@ -112,14 +113,15 @@ Resources:
       TemplateURL: https://s3.amazonaws.com/eijikominami/aws-cloudformation-templates/web-servers/waf.yaml
   SNSForDeployment:
     Condition: CreateSNSForDeployment
-    Type: AWS::CloudFormation::Stack
+    Type: 'AWS::Serverless::Application'
     Properties:
-      Parameters: 
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 1.0.11
+      Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
-      TemplateURL: https://s3.amazonaws.com/eijikominami/aws-cloudformation-templates/notification/sns.yaml
       Tags:
-        - Key: !Ref TagKey
-          Value: !Ref TagValue
+        createdby: !Ref TagValue
   # IAM
   IAMRoleForCrossRegionReplication:
     Condition: CrossRegionReplication

--- a/static-website-hosting-with-ssl/templates/template.yaml
+++ b/static-website-hosting-with-ssl/templates/template.yaml
@@ -117,7 +117,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/web-servers/templates/ssm.yaml
+++ b/web-servers/templates/ssm.yaml
@@ -280,6 +280,10 @@ Resources:
           - aws.ssm
         detail-type: 
           - Configuration Compliance State Change
+        # EC2 only
+        detail:
+          resource-id:
+            - prefix: i-
       Name: SystemManagerConfigurationCompliance
       State: ENABLED
       Targets:

--- a/web-servers/templates/template.yaml
+++ b/web-servers/templates/template.yaml
@@ -288,7 +288,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -304,7 +304,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.11
+        SemanticVersion: 1.0.13
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/web-servers/templates/template.yaml
+++ b/web-servers/templates/template.yaml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
 Description: AWSCloudFormationTemplates/web-servers creates a Network Load Balancer and EC2 instances for Web Servers.
 
 Parameters:
@@ -283,29 +284,31 @@ Resources:
       TemplateURL: https://s3.amazonaws.com/eijikominami/aws-cloudformation-templates/web-servers/waf.yaml
   SNSForAlert:
     Condition: CreateSNSForAlert
-    Type: AWS::CloudFormation::Stack
+    Type: 'AWS::Serverless::Application'
     Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 1.0.11
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
           - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
           - !Ref SNSForDeploymentArn
-      Parameters: 
+      Parameters:
         TopicName: !Sub Alert-createdby-${AWS::StackName}
-      TemplateURL: https://s3.amazonaws.com/eijikominami/aws-cloudformation-templates/notification/sns.yaml
       Tags:
-        - Key: !Ref TagKey
-          Value: !Ref TagValue
+        createdby: !Ref TagValue
   SNSForDeployment:
     Condition: CreateSNSForDeployment
-    Type: AWS::CloudFormation::Stack
+    Type: 'AWS::Serverless::Application'
     Properties:
-      Parameters: 
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 1.0.11
+      Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
-      TemplateURL: https://s3.amazonaws.com/eijikominami/aws-cloudformation-templates/notification/sns.yaml
       Tags:
-        - Key: !Ref TagKey
-          Value: !Ref TagValue
+        createdby: !Ref TagValue
   # IAM
   IAMRoleForEC2:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
**Why is this change necessary?**

1. Automatic updates of README files on AWS Serverless Application Repository.
2. Unify CFn resource type when nested stack is created.

**How does it address the issue?**

1. Update the build specification file to upload artifacts to AWS Serverless Application Repository.
2. Replace 'AWS::CloudFormation::Stack' resource type with 'AWS::Serverless::Application'

**What side effects does this change have?**

+ None at this point.