### PR TITLE
Fix: Add CAPABILITY_AUTO_EXPAND to the Capabilities parameter of the CI/CD template

### DIFF
--- a/cicd/templates/codebuild.yaml
+++ b/cicd/templates/codebuild.yaml
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -83,7 +83,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -320,7 +320,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -340,7 +340,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -360,7 +360,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -102,7 +102,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -118,7 +118,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -792,7 +792,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -812,7 +812,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -832,7 +832,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -731,7 +731,7 @@ Resources:
                 Configuration:
                   ActionMode: CREATE_UPDATE
                   StackName: SystemManager
-                  Capabilities: CAPABILITY_IAM,CAPABILITY_NAMED_IAM
+                  Capabilities: CAPABILITY_IAM,CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                   RoleArn: !GetAtt IAMRoleForCloudFormation.Arn
                   TemplatePath: Source-CloudFormationTemplatesArtifact::web-servers/templates/ssm.yaml
                   ParameterOverrides: '{"SNSTopicARN": { "Fn::GetParam": ["DeployArtifact-CICD", "Output.json", "SNSForAlertArn"]}}'

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -60,7 +60,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -116,7 +116,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -168,7 +168,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -218,7 +218,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -269,7 +269,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -320,7 +320,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -377,7 +377,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -436,7 +436,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -487,7 +487,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -537,7 +537,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -58,7 +58,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -114,7 +114,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -166,7 +166,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -216,7 +216,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -267,7 +267,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -318,7 +318,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -375,7 +375,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -434,7 +434,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -485,7 +485,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 
@@ -535,7 +535,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
   NotificationARNs: 
     - String
   Parameters: 

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -126,7 +126,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -142,7 +142,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -152,7 +152,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/eventbridge-rules
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/security/templates/template.yaml
+++ b/security/templates/template.yaml
@@ -165,7 +165,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -181,7 +181,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/static-website-hosting-with-ssl/templates/template.yaml
+++ b/static-website-hosting-with-ssl/templates/template.yaml
@@ -117,7 +117,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/web-servers/templates/template.yaml
+++ b/web-servers/templates/template.yaml
@@ -288,7 +288,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -304,7 +304,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.13
+        SemanticVersion: 1.0.14
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:


### PR DESCRIPTION
**Why is this change necessary?**

+ The SystemManager template requires the CAPABILITY_AUTO_EXPAND capability.

**How does it address the issue?**

+ Add ``CAPABILITY_AUTO_EXPAND`` to the Capabilities parameter of the template.

**What side effects does this change have?**

+ None at this point.