### PR TITLE
Change EventBridge parameters and create a new IAM Role for AWS Support

### DIFF
--- a/cicd/templates/codebuild.yaml
+++ b/cicd/templates/codebuild.yaml
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -83,7 +83,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -320,7 +320,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -340,7 +340,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -360,7 +360,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -102,7 +102,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -118,7 +118,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -792,7 +792,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -812,7 +812,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -832,7 +832,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -60,7 +60,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -116,7 +116,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -168,7 +168,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -218,7 +218,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -269,7 +269,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -320,7 +320,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -377,7 +377,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -436,7 +436,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -487,7 +487,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -537,7 +537,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -58,7 +58,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -114,7 +114,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -166,7 +166,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -216,7 +216,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -267,7 +267,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -318,7 +318,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -375,7 +375,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -434,7 +434,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -485,7 +485,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 
@@ -535,7 +535,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.14
+    SemanticVersion: 1.0.15
   NotificationARNs: 
     - String
   Parameters: 

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -244,7 +244,7 @@ Resources:
     Condition: CreateKMSKey
     Type: AWS::KMS::Key
     Properties: 
-      Description: String
+      Description: Encrypt Slack Webhook URL
       Enabled: true
       EnableKeyRotation: true
       KeyPolicy: 

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -126,7 +126,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -142,7 +142,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -152,7 +152,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/eventbridge-rules
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/security/README.md
+++ b/security/README.md
@@ -111,6 +111,7 @@ You can provide optional parameters as follows:
 | AuditOtherAccounts | Enabled / Disabled | Disabled | ○ | If it is Enabled, **Config Aggregator** is enabled. |
 | AuditOtherRegions | Enabled / Disabled | Enabled | ○ | If it is Enabled, **CloudTrail** and **Include Global Resource Types** option in Config are enabled. |
 | AutoRemediation | Enabled / Disabled | Enabled | ○ | If it is Enabled, **AutoRemediation** by SSM Automation and Lambda are enabled. |
+| IAMUserArnToAssumeAWSSupportRole | String | | | IAM User ARN to assume AWS Support role |
 
 ## Comply with Center for Internet Security (CIS) Benchmarks
 

--- a/security/README_JP.md
+++ b/security/README_JP.md
@@ -113,6 +113,7 @@ aws cloudformation deploy --template-file template.yaml --stack-name DefaultSecu
 | AuditOtherAccounts | Enabled / Disabled | Disabled | ○ | Enabledを指定した場合、**Config Aggregator** が有効化されます。 |
 | AuditOtherRegions | Enabled / Disabled | Enabled | ○ | Enabledを指定した場合、**CloudTrail** と Config の **Include Global Resource Types** オプションが有効化されます。 |
 | AutoRemediation | Enabled / Disabled | Enabled | ○ | Enabledを指定した場合、SSM Automation と Lambda を用いた **自動修復機能** が有効化されます。 |
+| IAMUserArnToAssumeAWSSupportRole | String | | | AWS Support ロールを引き受けるIAMユーザのARN |
 
 ## Center for Internet Security (CIS) ベンチマークへの準拠
 

--- a/security/templates/cloudtrail.yaml
+++ b/security/templates/cloudtrail.yaml
@@ -86,9 +86,32 @@ Resources:
       IncludeGlobalServiceEvents: true
       IsLogging: true
       IsMultiRegionTrail: true
+      KMSKeyId: !GetAtt KMSKey.Arn
       S3BucketName: !Ref S3ForCloudTrail
       TrailName: !Sub ${LogicalNamePrefix}
       Tags:
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+  # KMS
+  KMSKey:
+    Type: AWS::KMS::Key
+    Properties: 
+      Description: Encrypt CloudTrail Logs
+      Enabled: true
+      EnableKeyRotation: true
+      KeyPolicy: 
+        Version: 2012-10-17
+        Id: DefaultKeyPolicy
+        Statement:
+          - Sid: Enable IAM User Permissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: 'kms:*'
+            Resource: '*'
+      KeyUsage: ENCRYPT_DECRYPT
+      PendingWindowInDays: 30
+      Tags: 
         - Key: !Ref TagKey
           Value: !Ref TagValue
   # S3

--- a/security/templates/guardduty.yaml
+++ b/security/templates/guardduty.yaml
@@ -28,6 +28,7 @@ Resources:
     Properties: 
       Description: !Sub Rule for GuardDuty created by ${AWS::StackName}.
       # MEDIUM or higher
+      # https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/251
       EventPattern: |
         {
            "source": [

--- a/security/templates/template.yaml
+++ b/security/templates/template.yaml
@@ -24,6 +24,10 @@ Parameters:
      - Enabled
      - Disabled
     Description: Enable or disable auto remediation [required]
+  IAMUserArnToAssumeAWSSupportRole:
+    Type: String
+    AllowedPattern: ^arn:aws:iam::.+$
+    Description: IAM User ARN to assume AWS Support role
   SNSForAlertArn:
     Type: String
     Default: '' 
@@ -42,6 +46,7 @@ Parameters:
 Conditions:
   CreateSNSForAlert: !Equals [ !Ref SNSForAlertArn, '']
   CreateSNSForDeployment: !Equals [ !Ref SNSForDeploymentArn, '']
+  CreateIAMRoleForAWSSupport: !Not [ !Equals [ !Ref IAMUserArnToAssumeAWSSupportRole, ''] ]
 
 Resources:
   # Nested Stack
@@ -186,6 +191,25 @@ Resources:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
         createdby: !Ref TagValue
+  # IAM Role
+  IAMRoleForAWSSupport:
+    Condition: CreateIAMRoleForAWSSupport
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Ref IAMUserArnToAssumeAWSSupportRole
+            Action: 'sts:AssumeRole'
+      Description: A role required for CIS AWS Foundations to access AWS Support.
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AWSSupportAccess
+      RoleName: !Sub '${AWS::StackName}-AWSSupport-${AWS::Region}'
+      Tags:
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
   # S3
   S3ForAccessLog:
     Type: 'AWS::S3::Bucket'

--- a/security/templates/template.yaml
+++ b/security/templates/template.yaml
@@ -170,7 +170,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -186,7 +186,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/static-website-hosting-with-ssl/templates/template.yaml
+++ b/static-website-hosting-with-ssl/templates/template.yaml
@@ -117,7 +117,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/web-servers/templates/ssm.yaml
+++ b/web-servers/templates/ssm.yaml
@@ -263,9 +263,14 @@ Resources:
         source:
           - aws.ssm
         detail-type: 
+          - EC2 Command Status-change Notification
           - EC2 Command Invocation Status-change Notification
           - EC2 Automation Step Status-change Notification
           - EC2 Automation Execution Status-change Notification
+          - EC2 State Manager Association State Change
+          - EC2 State Manager Instance Association State Change
+        detail:
+          status: Failed
       Name: SystemManager
       State: ENABLED
       Targets:
@@ -298,6 +303,13 @@ Resources:
           - aws.ssm
         detail-type: 
           - Maintenance Window Target Registration Notification
+        detail:
+          status:
+            - CANCELLED 
+            - CANCELLING 
+            - FAILED 
+            - SKIPPED_OVERLAPPING 
+            - TIMED_OUT
       Name: SystemManagerMaintenanceWindow
       State: ENABLED
       Targets:

--- a/web-servers/templates/template.yaml
+++ b/web-servers/templates/template.yaml
@@ -288,7 +288,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -304,7 +304,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.14
+        SemanticVersion: 1.0.15
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:


### PR DESCRIPTION
**Why is this change necessary?**

1. Notifications are sent when System Manager events are successful.
2. CIS AWS Foundations 1.20 needs a new IAM Role for AWS Support.

**How does it address the issue?**

1. Notifications are sent only when System Manager events are failed.
2. Create a new IAM Role for AWS Support.

**What side effects does this change have?**

+ None at this point.