### PR TITLE
Improve the notification process and support S3 server-side encryption

### DIFF
--- a/cicd/README.md
+++ b/cicd/README.md
@@ -53,6 +53,7 @@ If you use [Template Configuration File](https://docs.aws.amazon.com/AWSCloudFor
 | [Security Template with Config Rule](../security-config-rules/README.md) | DefaultSecuritySettings-ConfigRules.json |
 | [Static Website Hosting Template](../static-website-hosting-with-ssl/README.md) | StaticWebsiteHosting.json |
 | [EC2-based Web Servers Template](../web-servers/README.md) | WebServers.json |
+| [System Manager Template](../web-servers/README_JP.md) | SystemManager.json |
 
 ## Deployment
 

--- a/cicd/README_JP.md
+++ b/cicd/README_JP.md
@@ -54,6 +54,7 @@ aws s3api create-bucket --bucket my-bucket --region us-east-1
 | [Security Template with Config Rule](../security-config-rules/README_JP.md) | DefaultSecuritySettings-ConfigRules.json |
 | [Static Website Hosting Template](../static-website-hosting-with-ssl/README_JP.md) | StaticWebsiteHosting.json |
 | [EC2-based Web Servers Template](../web-servers/README_JP.md) | WebServers.json |
+| [System Manager Template](../web-servers/README_JP.md) | SystemManager.json |
 
 ## デプロイ
 

--- a/cicd/codepipeline-default-settings.md
+++ b/cicd/codepipeline-default-settings.md
@@ -42,6 +42,7 @@ If you use [Template Configuration File](https://docs.aws.amazon.com/AWSCloudFor
 | [Security Template with Config Rule](https://github.com/eijikominami/aws-cloudformation-templates/tree/master/security-config-rules/README.md) | DefaultSecuritySettings-ConfigRules.json |
 | [Static Website Hosting Template](https://github.com/eijikominami/aws-cloudformation-templates/tree/master/static-website-hosting-with-ssl/README.md) | StaticWebsiteHosting.json |
 | [EC2-based Web Servers Template](https://github.com/eijikominami/aws-cloudformation-templates/tree/master/web-servers/README.md) | Notification.json |
+| [System Manager Template](https://github.com/eijikominami/aws-cloudformation-templates/tree/master/web-servers/README.md) | SystemManager.json |
 
 ## Deployment
 
@@ -112,6 +113,7 @@ aws s3api create-bucket --bucket my-bucket --region us-east-1
 | [Security Template with Config Rule](https://github.com/eijikominami/aws-cloudformation-templates/tree/master/security-config-rules/README_JP.md) | DefaultSecuritySettings-ConfigRules.json |
 | [Static Website Hosting Template](https://github.com/eijikominami/aws-cloudformation-templates/tree/master/static-website-hosting-with-ssl/README_JP.md) | StaticWebsiteHosting.json |
 | [EC2-based Web Servers Template](https://github.com/eijikominami/aws-cloudformation-templates/tree/master/web-servers/README_JP.md) | Notification.json |
+| [System Manager Template](https://github.com/eijikominami/aws-cloudformation-templates/tree/master/web-servers/README_JP.md) | SystemManager.json |
 
 ## デプロイ
 

--- a/cicd/templates/codebuild.yaml
+++ b/cicd/templates/codebuild.yaml
@@ -67,7 +67,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -83,7 +83,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -320,7 +320,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -340,7 +340,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -360,7 +360,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -102,7 +102,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -118,7 +118,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -792,7 +792,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -812,7 +812,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -832,7 +832,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -60,7 +60,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -116,7 +116,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -168,7 +168,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -218,7 +218,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -269,7 +269,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -320,7 +320,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -377,7 +377,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -437,7 +437,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -488,7 +488,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -538,7 +538,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -408,6 +408,7 @@ You can provide optional parameters as follows.
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | |
 | `FunctionResouceName` | String | | ○ | |
+| `MetricFilterPattern` | String | ?Error ?Exception | ○ | Metric filter pattern | 
 | `SNSTopicArn` | String | | ○ | |
 | `TimeoutMilliseconds` | Integer | 24000 | ○ | |
 

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -58,7 +58,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-apigateway
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -114,7 +114,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -166,7 +166,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb-throttle
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -216,7 +216,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-dynamodb
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -267,7 +267,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -318,7 +318,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -375,7 +375,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -435,7 +435,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -486,7 +486,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 
@@ -536,7 +536,7 @@ Type: 'AWS::Serverless::Application'
 Properties:
   Location:
     ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-sns
-    SemanticVersion: 1.0.15
+    SemanticVersion: 1.0.16
   NotificationARNs: 
     - String
   Parameters: 

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -406,6 +406,7 @@ Properties:
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | |
 | `FunctionResouceName` | String | | ○ | |
+| `MetricFilterPattern` | String | ?Error ?Exception | ○ | メトリックフィルタパターン | 
 | `SNSTopicArn` | String | | ○ | |
 | `TimeoutMilliseconds` | Integer | 24000 | ○ | |
 

--- a/monitoring/cloudwatch-alarm-about-lambda.md
+++ b/monitoring/cloudwatch-alarm-about-lambda.md
@@ -24,6 +24,7 @@ You can provide optional parameters as follows.
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | |
 | `FunctionResouceName` | String | | ○ | |
+| `MetricFilterPattern` | String | ?Error ?Exception | ○ | Metric filter pattern | 
 | `SNSTopicArn` | String | | ○ | |
 | `TimeoutMilliseconds` | Integer | 24000 | ○ | |
 
@@ -51,5 +52,6 @@ cloudwatch-alarm-about-apigateway は、AWS Lambda に関する Amazon CloudWatc
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | |
 | `FunctionResouceName` | String | | ○ | |
+| `MetricFilterPattern` | String | ?Error ?Exception | ○ | メトリックフィルタパターン | 
 | `SNSTopicArn` | String | | ○ | |
 | `TimeoutMilliseconds` | Integer | 24000 | ○ | |

--- a/monitoring/sam-app/lambda.yaml
+++ b/monitoring/sam-app/lambda.yaml
@@ -7,6 +7,11 @@ Parameters:
     Type: String
     Default: ''
     Description: Custom Alram name
+  MetricFilterPattern:
+    Type: String
+    Default: '?Error ?Exception'
+    AllowedPattern: .+
+    Description: Metric filter pattern [required]
   SNSTopicArn:
     Type: String
     AllowedPattern: .+
@@ -109,7 +114,7 @@ Resources:
   MetricFilterErrorLog:
     Type: 'AWS::Logs::MetricFilter'
     Properties:
-      FilterPattern: '?Error ?Exception'
+      FilterPattern: !Ref MetricFilterPattern
       LogGroupName: !Sub /aws/lambda/${FunctionResouceName}
       MetricTransformations:
         - MetricName: !Sub ${FunctionResouceName}-ErrorLog

--- a/notification/sam-app/sendNotificationToSlack/lambda_function.py
+++ b/notification/sam-app/sendNotificationToSlack/lambda_function.py
@@ -66,7 +66,11 @@ def lambda_handler(event, context):
             # TrustedAdvisor
             elif 'source' in message and 'aws.trustedadvisor' in message['source']:  
                 hook_url = "https://" + ALERT_HOOK_URL
-                slack_message = createTrustedAdvisorMessage(message)                    
+                slack_message = createTrustedAdvisorMessage(message)      
+            # IAM Access Analyzer
+            elif 'source' in message and 'aws.access-analyzer' in message['source']:  
+                hook_url = "https://" + ALERT_HOOK_URL
+                slack_message = createIAMAccessAnalyzer(message)                 
         else:
             # Amplify Console
             if 'AWS Amplify Console' in message:
@@ -391,6 +395,36 @@ def createTrustedAdvisorMessage(message):
         }]
     }
 
+@xray_recorder.capture('createIAMAccessAnalyzer')
+def createIAMAccessAnalyzer(message):
+
+    actions = ''
+    title = ":heavy_exclamation_mark: IAM Access Analyzer Findings | " + message['region'] + " | Account: " + message['account']
+    title_link = "https://console.aws.amazon.com/resource-groups/access-analyzer/home?region=" + message['region']
+
+    return {
+        'attachments': [{
+            'color': '#961D13',
+            'title': "%s" % title,
+            'title_link': "%s" % title_link,
+            'text': "*IAM Access Analyzer* が %s に対する *%s* 権限を検知しました。 *意図していない権限の場合は、潜在的なセキュリティリスクが存在するため、この権限を許可するポリシーを変更または削除してください* 。ビジネスプロセスに必要なアクセスなど、アクセスが意図している場合は、結果をアーカイブできます。" % (message['detail']['resource'], actions),
+            'fields': [
+                    {
+                        'title': "Principal",
+                        'value': "%s" % str(message['detail']['principal'])
+                    },
+                    {
+                        'title': "Actions",
+                        'value': "%s" % actions
+                    },
+                    {
+                        'title': "Resource",
+                        'value': "%s" % message['detail']['resource']
+                    },
+                ]
+        }]
+    }
+
 @xray_recorder.capture('createAmplifyMessages')
 def createAmplifyMessage(message):
     if 'FAILED' in message:
@@ -438,4 +472,4 @@ def sendMessage(hook_url, message):
             return False
         except URLError as e:
             logger.error("Server connection failed: %s at %s.", e.reason, sys._getframe().f_code.co_name)
-            return False
+            return False   

--- a/notification/sam-app/sendNotificationToSlack/lambda_function.py
+++ b/notification/sam-app/sendNotificationToSlack/lambda_function.py
@@ -70,15 +70,18 @@ def lambda_handler(event, context):
             # IAM Access Analyzer
             elif 'source' in message and 'aws.access-analyzer' in message['source']:  
                 hook_url = "https://" + ALERT_HOOK_URL
-                slack_message = createIAMAccessAnalyzer(message)                 
+                slack_message = createIAMAccessAnalyzer(message)
+            else:
+                hook_url = None
+                slack_message = None                           
         else:
             # Amplify Console
             if 'AWS Amplify Console' in message:
                 hook_url = "https://" + DEPLOYMENT_HOOK_URL
                 slack_message = createAmplifyMessage(message)
             else:
-                hook_url = "https://" + ALERT_HOOK_URL            
-                slack_message = {'text': message}
+                hook_url = None     
+                slack_message = None
     except json.decoder.JSONDecodeError as e:
         logger.error("JSON decode error: %s at %s.", e.msg, sys._getframe().f_code.co_name)
     # Sends Slack

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -126,7 +126,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -142,7 +142,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -152,7 +152,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/eventbridge-rules
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -320,157 +320,6 @@ Resources:
         - CreateSNSForAlert
         - !GetAtt SNSForAlert.Outputs.SNSTopicArn
         - !Ref SNSForAlertArn
-  # CloudWatch Alarm for Lambda
-  AlarmLambdaSendNotificationToSlackErrors:
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      ActionsEnabled: true
-      AlarmActions: 
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      AlarmDescription: !Sub 'Lambda *${LambdaSendNotificationToSlack}()* でエラーが発生しています。'
-      AlarmName: !Sub 'Warning-${AWS::StackName}-Lambda-${LambdaSendNotificationToSlack}-Errors'
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref LambdaSendNotificationToSlack
-        - Name: Resource
-          Value: !Ref LambdaSendNotificationToSlack
-      EvaluationPeriods: 1
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      OKActions: 
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      # Alert when Sum is over 1 count in 60 seconds.
-      Period: 60
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: notBreaching
-  AlarmLambdaSendNotificationToSlackClientError:
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      ActionsEnabled: true
-      AlarmActions: 
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      AlarmDescription: !Sub 'Lambda *${LambdaSendNotificationToSlack}()* でクライアントエラーが発生しています。'
-      AlarmName: !Sub 'Warning-${AWS::StackName}-Lambda-${LambdaSendNotificationToSlack}-ClientError'
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref LambdaSendNotificationToSlack
-        - Name: Resource
-          Value: !Ref LambdaSendNotificationToSlack
-      EvaluationPeriods: 1
-      MetricName: ClientError
-      Namespace: AWS/Lambda
-      OKActions: 
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      # Alert when Sum is over 1 count in 60 seconds.
-      Period: 60
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: notBreaching
-  AlarmLambdaSendNotificationToSlackTypeError:
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      ActionsEnabled: true
-      AlarmActions: 
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      AlarmDescription: !Sub 'Lambda *${LambdaSendNotificationToSlack}()* でタイプエラーが発生しています。'
-      AlarmName: !Sub 'Warning-${AWS::StackName}-Lambda-${LambdaSendNotificationToSlack}-TypeError'
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref LambdaSendNotificationToSlack
-        - Name: Resource
-          Value: !Ref LambdaSendNotificationToSlack
-      EvaluationPeriods: 1
-      MetricName: TypeError
-      Namespace: AWS/Lambda
-      OKActions: 
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      # Alert when Sum is over 1 count in 60 seconds.
-      Period: 60
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: notBreaching
-  AlarmLambdaSendNotificationToSlackTimeoutWillOccur:
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      AlarmDescription: !Sub 'Lambda *${LambdaSendNotificationToSlack}()* の実行時間がタイムアウト値に近づいています。'
-      AlarmName: !Sub 'Warning-${AWS::StackName}-Lambda-${LambdaSendNotificationToSlack}-Timeout-Will-Occur'
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref LambdaSendNotificationToSlack
-        - Name: Resource
-          Value: !Ref LambdaSendNotificationToSlack
-      EvaluationPeriods: 1
-      MetricName: Duration
-      Namespace: AWS/Lambda
-      OKActions:
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      # Alert when Sum is over 1 count in 60 seconds.
-      Period: 60
-      Statistic: Maximum
-      Threshold: 24000
-      TreatMissingData: notBreaching
-  AlarmLambdaSendNotificationToSlackThrottles:
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      AlarmDescription: !Sub 'Lambda *${LambdaSendNotificationToSlack}()* でスロットリングが発生しています。'
-      AlarmName: !Sub 'Warning-${AWS::StackName}-Lambda-${LambdaSendNotificationToSlack}-Throttles'
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref LambdaSendNotificationToSlack
-        - Name: Resource
-          Value: !Ref LambdaSendNotificationToSlack
-      EvaluationPeriods: 1
-      MetricName: Throttles
-      Namespace: AWS/Lambda
-      OKActions:
-        - !If
-          - CreateSNSForAlert
-          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
-          - !Ref SNSForAlertArn
-      # Alert when Sum is over 1 count in 60 seconds.
-      Period: 60
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: notBreaching
   # Chatbot
   ChatbotForDeployment:
     Condition: CreateChatbotForDeployment

--- a/security/README.md
+++ b/security/README.md
@@ -45,6 +45,7 @@ This template enables ``Amazon GuardDuty``. ``Amazon GuardDuty`` only sends noti
 ### AWS CloudTrail
 
 This template enables ``AWS CloudTrail`` and creates an ``S3 Bucket`` when its logs are stored.
+CloudTrail Logs stored in an S3 bucket are encrypted using ``AWS KMS CMKs``.
 
 ### Amazon Inspector
 
@@ -83,6 +84,7 @@ The following rules enable ``Automatic Remediation`` feature and attached ``SSM 
 
 + [iam-password-policy](https://docs.aws.amazon.com/config/latest/developerguide/iam-password-policy.html)
 + [iam-root-access-key-check](https://docs.aws.amazon.com/config/latest/developerguide/iam-root-access-key-check.html)
++ [s3-bucket-server-side-encryption-enabled](https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-server-side-encryption-enabled.html)
 + [vpc-flow-logs-enabled](https://docs.aws.amazon.com/config/latest/developerguide/vpc-flow-logs-enabled.html)
 + [vpc-sg-open-only-to-authorized-ports](https://docs.aws.amazon.com/config/latest/developerguide/vpc-sg-open-only-to-authorized-ports.html)
 + [vpc-default-security-group-closed](https://docs.aws.amazon.com/config/latest/developerguide/vpc-default-security-group-closed.html)
@@ -113,7 +115,7 @@ You can provide optional parameters as follows:
 | AutoRemediation | Enabled / Disabled | Enabled | ○ | If it is Enabled, **AutoRemediation** by SSM Automation and Lambda are enabled. |
 | IAMUserArnToAssumeAWSSupportRole | String | | | IAM User ARN to assume AWS Support role |
 
-## Comply with Center for Internet Security (CIS) Benchmarks
+## Comply with the Center for Internet Security (CIS) Benchmarks
 
 This template helps you to comply with the Center for Internet Security (CIS) Benchmarks.
 
@@ -153,3 +155,34 @@ This template helps you to comply with the Center for Internet Security (CIS) Be
 | 4.1| Ensure no security groups allow ingress from 0.0.0.0/0 to port 22 | **Config** checks it and **SSM Automation** remediates the rules automatically. |
 | 4.2| Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389 | **Config** checks it and **SSM Automation** remediates the rules automatically. |
 | 4.3| Ensure the default security group of every VPC restricts all traffic | **Config** checks it and **SSM Automation** remediates the default security group automatically. |
+
+## Comply with the PCI DSS controls
+
+This template helps you to comply with the PCI DSS controls.
+
+| No. | Rules | Remediation |
+| --- | --- | --- |
+| PCI.CloudTrail.1 | CloudTrail logs should be encrypted at rest using AWS KMS CMKs.  | This template enables **CloudTrail** and related resources in all Regions. |
+| PCI.CloudTrail.2 | CloudTrail should be enabled. | This template enables **CloudTrail** and related resources in all Regions. |
+| PCI.CloudTrail.3 | CloudTrail log file validation should be enabled. | This template enables **CloudTrail** and related resources in all Regions. |
+| PCI.CloudTrail.4 | CloudTrail trails should be integrated with CloudWatch Logs. | This template enables **CloudTrail** and related resources in all Regions. |
+| PCI.Config.1 | AWS Config should be enabled. | This template enables **Config** and related resources in all Regions.  |
+| PCI.CW.1 | A log metric filter and alarm should exist for usage of the "root" user. |  |
+| PCI.EC2.2 | VPC default security group should prohibit inbound and outbound traffic. | **Config** checks it and **SSM Automation** remediates the default security group automatically. |
+| PCI.IAM.1 | IAM root user access key should not exist. | **Config** checks it and **SSM Automation** remediates the default security group automatically. |
+| PCI.S3.4 | S3 buckets should have server-side encryption enabled. | **Config** checks it and **SSM Automation** remediates the default security group automatically.s |
+
+## Comply with the AWS Foundational Security Best Practices standard 
+
+This template helps you to comply with the AWS Foundational Security Best Practices standard.
+
+| No. | Rules | Remediation |
+| --- | --- | --- |
+| CloudTrail.1 | CloudTrail should be enabled and configured with at least one multi-Region trail. | This template enables **CloudTrail** and related resources in all Regions. |
+| CloudTrail.2 | CloudTrail should have encryption at-rest enabled. | This template enables **CloudTrail** and related resources in all Regions. |
+| Config.1 | AWS Config should be enabled. | This template enables **Config** and related resources in all Regions. |
+| EC2.2 | The VPC default security group should not allow inbound and outbound traffic. | **Config** checks it and **SSM Automation** remediates the default security group automatically. |
+| GuardDuty.1 | GuardDuty should be enabled. | This template enables **GuardDuty** and related resources in all Regions. |
+| IAM.3 | IAM users' access keys should be rotated every 90 days or less. | **Config** checks it and **SSM Automation** remediates the default security group automatically. |
+| IAM.4 | IAM root user access key should not exist. | **Config** checks it and **SSM Automation** remediates the default security group automatically. |
+| S3.4 | S3 buckets should have server-side encryption enabled. | **Config** checks it and **SSM Automation** remediates the default security group automatically. |

--- a/security/README_JP.md
+++ b/security/README_JP.md
@@ -49,6 +49,7 @@ IAM Access Analyzer は、 ``Amazon EventBridge`` 経由で ``Amazon SNS`` に�
 ### AWS CloudTrail
 
 このテンプレートは、 ``AWS CloudTrail`` を有効化し、ログを蓄積する ``S3バケット`` を生成します。
+S3バケットに蓄積されたログは、``AWS KMS`` 上で作成された ``CMK`` によって暗号化されます。
 
 ### Amazon Inspector
 
@@ -87,6 +88,7 @@ Amazon Inspector は、``Amazon CloudWatch Events``　によって **毎週月�
 
 + [iam-password-policy](https://docs.aws.amazon.com/config/latest/developerguide/iam-password-policy.html)
 + [iam-root-access-key-check](https://docs.aws.amazon.com/config/latest/developerguide/iam-root-access-key-check.html)
++ [s3-bucket-server-side-encryption-enabled](https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-server-side-encryption-enabled.html)
 + [vpc-flow-logs-enabled](https://docs.aws.amazon.com/config/latest/developerguide/vpc-flow-logs-enabled.html)
 + [vpc-sg-open-only-to-authorized-ports](https://docs.aws.amazon.com/config/latest/developerguide/vpc-sg-open-only-to-authorized-ports.html)
 + [vpc-default-security-group-closed](https://docs.aws.amazon.com/config/latest/developerguide/vpc-default-security-group-closed.html)
@@ -157,3 +159,34 @@ aws cloudformation deploy --template-file template.yaml --stack-name DefaultSecu
 | 4.1| どのセキュリティグループでも 0.0.0.0/0 からポート 22 への入力を許可しないようにします | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |
 | 4.2| どのセキュリティグループでも 0.0.0.0/0 からポート 3389 への入力を許可しないようにします | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |
 | 4.3| すべての VPC のデフォルトセキュリティグループがすべてのトラフィックを制限するようにします | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |
+
+## PCI DSS セキュリティ標準への準拠
+
+このテンプレートを実行することで、PCI DSS セキュリティ標準の以下の項目に準拠します。
+
+| No. | Rules | Remediation |
+| --- | --- | --- |
+| PCI.CloudTrail.1 | CloudTrail ログは、AWS KMS CMK を使用して保存時に暗号化する必要があります。 | **CloudTrail** と関連サービスを有効化します。 |
+| PCI.CloudTrail.2 | CloudTrail を有効にする必要があります。 | **CloudTrail** と関連サービスを有効化します。 |
+| PCI.CloudTrail.3 | CloudTrail ログファイルの検証を有効にする必要があります。 | **CloudTrail** と関連サービスを有効化します。 |
+| PCI.CloudTrail.4 | CloudTrail 証跡は CloudWatch ログと統合する必要があります。 | **CloudTrail** と関連サービスを有効化します。 |
+| PCI.Config.1 | AWS Config を有効にする必要があります。 | **Config** と関連サービスを有効化します。 |
+| PCI.CW.1 | 「root」ユーザーの使用には、ログメトリクスフィルターとアラームが存在する必要があります。 | ログメトリクスフィルタとCloudWatchアラームを作成します。 |
+| PCI.EC2.2 | VPC のデフォルトのセキュリティグループでは、インバウンドトラフィックとアウトバウンドトラフィックが禁止されます。 | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |
+| PCI.IAM.1 | IAM ルートユーザーアクセスキーが存在してはいけません。 | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |
+| PCI.S3.4 | S3 バケットでは、サーバー側の暗号化を有効にする必要があります。 | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |
+
+## AWS の基本的なセキュリティのベストプラクティス標準への準拠
+
+このテンプレートを実行することで、AWS の基本的なセキュリティのベストプラクティス標準の以下の項目に準拠します。
+
+| No. | Rules | Remediation |
+| --- | --- | --- |
+| CloudTrail.1 | CloudTrail を有効にし、少なくとも 1 つのマルチリージョンの証跡で設定する必要があります。 | **CloudTrail** と関連サービスを有効化します。 |
+| CloudTrail.2 | CloudTrail は保管時の暗号化を有効にする必要があります。 | **CloudTrail** と関連サービスを有効化します。 |
+| Config.1 | AWS Config を有効にする必要があります。 | **Config** と関連サービスを有効化します。 |
+| EC2.2 | VPC のデフォルトのセキュリティグループでは、インバウンドトラフィックとアウトバウンドトラフィックが禁止されます。 | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |
+| GuardDuty.1 | GuardDuty を有効にする必要があります。 | **GuardDuty** と関連サービスを有効化します。 |
+| IAM.3 | IAM ユーザーのアクセスキーは 90 日ごとに更新する必要があります。 | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |
+| IAM.4 | IAM ルートユーザーアクセスキーが存在してはいけません。 | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |
+| S3.4 | S3 バケットでは、サーバー側の暗号化を有効にする必要があります。 | **Config** で定期的に確認を行い、非準拠の場合は **SSM Automation** で自動修復を行います。 |

--- a/security/README_JP.md
+++ b/security/README_JP.md
@@ -164,7 +164,7 @@ aws cloudformation deploy --template-file template.yaml --stack-name DefaultSecu
 
 このテンプレートを実行することで、PCI DSS セキュリティ標準の以下の項目に準拠します。
 
-| No. | Rules | Remediation |
+| No. | ルール | 実行内容 |
 | --- | --- | --- |
 | PCI.CloudTrail.1 | CloudTrail ログは、AWS KMS CMK を使用して保存時に暗号化する必要があります。 | **CloudTrail** と関連サービスを有効化します。 |
 | PCI.CloudTrail.2 | CloudTrail を有効にする必要があります。 | **CloudTrail** と関連サービスを有効化します。 |
@@ -180,7 +180,7 @@ aws cloudformation deploy --template-file template.yaml --stack-name DefaultSecu
 
 このテンプレートを実行することで、AWS の基本的なセキュリティのベストプラクティス標準の以下の項目に準拠します。
 
-| No. | Rules | Remediation |
+| No. | ルール | 実行内容 |
 | --- | --- | --- |
 | CloudTrail.1 | CloudTrail を有効にし、少なくとも 1 つのマルチリージョンの証跡で設定する必要があります。 | **CloudTrail** と関連サービスを有効化します。 |
 | CloudTrail.2 | CloudTrail は保管時の暗号化を有効にする必要があります。 | **CloudTrail** と関連サービスを有効化します。 |

--- a/security/templates/config.yaml
+++ b/security/templates/config.yaml
@@ -181,6 +181,8 @@ Resources:
                   - 'ec2:RevokeSecurityGroupIngress'
                   - 'ec2:RevokeSecurityGroupEgress'
                   - 'ec2:DescribeSecurityGroups'
+                  - 's3:PutBucketEncryption'
+                  - 's3:PutEncryptionConfiguration'
                 Resource:
                   - '*'
       RoleName: !Sub '${LogicalNamePrefix}-SSM-${AWS::Region}'
@@ -649,6 +651,38 @@ Resources:
       Tags:
         - Key: !Ref TagKey
           Value: !Ref TagValue
+  # PCI S3.4 S3 buckets should have server-side encryption enabled 
+  # AWS Foundational Security Best Practices S3.4 S3 buckets should have server-side encryption enabled
+  ConfigS3BucketServerSideEncryptionEnabled:
+    # Must create a configuration recorder before you can create or update a Config rule.
+    DependsOn:
+      - ConfigConfigurationRecorder
+    Type: 'AWS::Config::ConfigRule'
+    Properties:
+      ConfigRuleName: s3-bucket-server-side-encryption-enabled
+      Description: Amazon S3 バケットで Amazon S3 のデフォルトの暗号化が有効になっていること、または S3 バケットポリシーでサーバー側の暗号化なしの put-object リクエストを明示的に拒否することを確認します。 
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED  
+  ConfigS3BucketServerSideEncryptionEnabledRemediationConfiguration:
+    Condition: CreateRemediationResources
+    Type: 'AWS::Config::RemediationConfiguration'
+    Properties:
+      # NOTE: AutomationAssumeRole, MaximumAutomaticAttempts and RetryAttemptSeconds are Required if Automatic is true.
+      Automatic: true
+      ConfigRuleName: !Ref ConfigS3BucketServerSideEncryptionEnabled
+      MaximumAutomaticAttempts: 1
+      Parameters:
+        AutomationAssumeRole:
+          StaticValue:
+            Values:
+              - !GetAtt IAMRoleForSSM.Arn
+        BucketName:
+          ResourceValue:
+            Value: RESOURCE_ID
+      RetryAttemptSeconds: 30
+      TargetId: AWS-EnableS3BucketEncryption
+      TargetType: SSM_DOCUMENT
   # S3
   S3ForConfig:
     Type: 'AWS::S3::Bucket'

--- a/security/templates/template.yaml
+++ b/security/templates/template.yaml
@@ -170,7 +170,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -186,7 +186,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/static-website-hosting-with-ssl/templates/template.yaml
+++ b/static-website-hosting-with-ssl/templates/template.yaml
@@ -117,7 +117,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/web-servers/templates/template.yaml
+++ b/web-servers/templates/template.yaml
@@ -288,7 +288,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -304,7 +304,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 1.0.15
+        SemanticVersion: 1.0.16
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:


### PR DESCRIPTION
**Why is this change necessary?**

1. Both Chatbot and Lambda does NOT support events from IAM Access Analyzer.
2. `sendNotificationToSlack()` does NOT work when it receives events from CloudFormation.
3. This template does NOT support `AWS Foundational Security Best Practices S3.4`.

**How does it address the issue?**

1. `sendNotificationToSlack()` supports events from IAM Access Analyzer.
2. fix `sendNotificationToSlack()`.
3. add a config rule about S3 server-side encryption.

**What side effects does this change have?**

+ None at this point.