### PR TITLE
Add new CloudWatch alarms

### DIFF
--- a/amplify/templates/template.yaml
+++ b/amplify/templates/template.yaml
@@ -260,6 +260,25 @@ Resources:
       Tags:
         environment: !Ref Environment
         createdby: !Ref TagValue
+  # CloudWatch
+  CloudWatchAlarmConfig:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-amplify
+        SemanticVersion: 2.2.9
+      NotificationARNs: 
+        - !Ref SNSForDeploymentArn
+      Parameters:
+        AppId: !GetAtt AmplifyConsole.AppId
+        CustomAlarmName: !Ref AWS::StackName
+        SNSTopicArn: !Ref SNSForAlertArn
+        Environment: !Ref Environment
+        TagKey: !Ref TagKey
+        TagValue: !Ref TagValue
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
 
 Outputs:
   AmplifyAppId:

--- a/amplify/templates/template.yaml
+++ b/amplify/templates/template.yaml
@@ -47,9 +47,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -77,7 +79,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -94,7 +96,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -238,7 +240,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -264,7 +266,7 @@ Outputs:
     Description: Amplify Console App Id
     Value: !GetAtt AmplifyConsole.AppId
   SNSForDeploymentArn:
-    Description: SNS Topic ARN
+    Description: The Amazon SNS topic ARN for deployment information
     Value: !If
       - CreateSNSForDeployment
       - !GetAtt SNSForDeployment.Outputs.SNSTopicArn

--- a/analytics/sam-app/googleanalytics-appflow.yaml
+++ b/analytics/sam-app/googleanalytics-appflow.yaml
@@ -57,9 +57,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -88,7 +90,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -105,7 +107,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -410,7 +412,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-appflow
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/analytics/sam-app/googleanalytics.yaml
+++ b/analytics/sam-app/googleanalytics.yaml
@@ -101,9 +101,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -133,7 +135,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -150,7 +152,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/analytics/sam-app/template.yaml
+++ b/analytics/sam-app/template.yaml
@@ -89,9 +89,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -123,7 +125,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -140,7 +142,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/cicd/templates/codebuild.yaml
+++ b/cicd/templates/codebuild.yaml
@@ -144,7 +144,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -161,7 +161,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -178,7 +178,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${LogicalName}
       Tags:
@@ -576,7 +576,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -601,7 +601,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -626,7 +626,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -868,7 +868,7 @@ Resources:
                   TemplatePath: BuildArtifact_Notification::packaged.yaml
                   ParameterOverrides: !Join
                     - ''
-                    - - !Sub '{"SNSForAlertArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForAlertArn"]}, "SNSForCICDArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForCICDArn"]}, "SNSForDeploymentArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForDeploymentArn"]}, "Environment": "'
+                    - - !Sub '{"AlarmLevel": "${AlarmLevel}", "SNSForAlertArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForAlertArn"]}, "SNSForCICDArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForCICDArn"]}, "SNSForDeploymentArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForDeploymentArn"]}, "Environment": "'
                       - !If
                         - Development
                         - development
@@ -1180,7 +1180,7 @@ Resources:
                   TemplatePath: Source_CloudFormationTemplatesArtifact::cicd/templates/upload-artifacts.yaml
                   ParameterOverrides: !Join 
                     - ''
-                    - - !Sub '{"AlarmLevel": "${AlarmLevel}", "CodeStarConnectionArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "CodeStarConnectionArn"]}, "SNSForAlertArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForAlertArn"]}, "SNSForDeploymentArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForDeploymentArn"]},"Environment": "'
+                    - - !Sub '{"AlarmLevel": "${AlarmLevel}", "CodeStarConnectionArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "CodeStarConnectionArn"]}, "SNSForAlertArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForAlertArn"]}, "SNSForDeploymentArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForDeploymentArn"]}, "SNSForCICDArn": { "Fn::GetParam": ["DeployArtifact_CICD", "Output.json", "SNSForCICDArn"]}, "Environment": "'
                       - !If
                         - Development
                         - development

--- a/cicd/templates/template.yaml
+++ b/cicd/templates/template.yaml
@@ -216,7 +216,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -236,7 +236,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -251,7 +251,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -1218,7 +1218,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -1249,7 +1249,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-codebuild
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -1280,7 +1280,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -1420,19 +1420,19 @@ Outputs:
    Description: The Amazon Resource Name (ARN) of the CodeStar connection
    Value: !GetAtt CodeStarConnection.ConnectionArn
   SNSForAlertArn:
-    Description: SNS ARN for Alert
+    Description: The Amazon SNS topic ARN for alert
     Value: !If
       - CreateSNSForAlert
       - !GetAtt SNSForAlert.Outputs.SNSTopicArn
       - !Ref SNSForAlertArn
   SNSForCICDArn:
-    Description: SNS ARN for CICD
+    Description: The Amazon SNS topic ARN for CI/CD information
     Value: !If
       - CreateSNSForCICD
       - !GetAtt SNSForCICD.Outputs.SNSTopicArn
       - !Ref SNSForCICDArn
   SNSForDeploymentArn:
-    Description: SNS ARN for Deployment
+    Description: The Amazon SNS topic ARN for deployment information
     Value: !If
       - CreateSNSForDeployment
       - !GetAtt SNSForDeployment.Outputs.SNSTopicArn

--- a/cicd/templates/upload-artifacts.yaml
+++ b/cicd/templates/upload-artifacts.yaml
@@ -109,6 +109,10 @@ Parameters:
     Type: String
     Default: '' 
     Description: The Amazon SNS topic ARN for deployment information
+  SNSForCICDArn:
+    Type: String
+    Default: '' 
+    Description: The Amazon SNS topic ARN for CI/CD
   Environment:
     Type: String
     Default: production
@@ -129,6 +133,7 @@ Conditions:
   CreateCloudFormation: !Not [ !Equals [ !Ref CodeStarConnectionArn, ''] ]
   CreateSNSForAlert: !Equals [ !Ref SNSForAlertArn, '']
   CreateSNSForDeployment: !Equals [ !Ref SNSForDeploymentArn, '']
+  CreateSNSForCICD: !Equals [ !Ref SNSForCICDArn, '']
   Development: !Equals [ !Ref Environment, development]
 
 Resources:
@@ -162,6 +167,18 @@ Resources:
       Tags:
         environment: !Ref Environment
         createdby: !Ref TagValue
+  SNSForCICD:
+    Condition: CreateSNSForCICD
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 2.2.8
+      Parameters:
+        TopicName: !Sub CICD-createdby-${AWS::StackName}
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
   CodeBuild:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -191,6 +208,10 @@ Resources:
           - CreateSNSForDeployment
           - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
           - !Ref SNSForDeploymentArn
+        SNSForCICDArn: !If
+          - CreateSNSForCICD
+          - !GetAtt SNSForCICD.Outputs.SNSTopicArn
+          - !Ref SNSForCICDArn
         LogicalName: !Ref AWS::StackName
         Environment: !Ref Environment
         TagKey: !Ref TagKey

--- a/cicd/templates/upload-artifacts.yaml
+++ b/cicd/templates/upload-artifacts.yaml
@@ -112,7 +112,7 @@ Parameters:
   SNSForCICDArn:
     Type: String
     Default: '' 
-    Description: The Amazon SNS topic ARN for CI/CD
+    Description: The Amazon SNS topic ARN for CI/CD information
   Environment:
     Type: String
     Default: production
@@ -144,7 +144,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -161,7 +161,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -173,7 +173,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub CICD-createdby-${AWS::StackName}
       Tags:

--- a/cloudops/templates/applicationinsights.yaml
+++ b/cloudops/templates/applicationinsights.yaml
@@ -19,7 +19,7 @@ Parameters:
   SNSForAlertArn:
     Type: String
     AllowedPattern: .+
-    Description: The ARN of an Amazon SNS topic [required]
+    Description: The Amazon SNS topic ARN for alert [required]
   Environment:
     Type: String
     Default: production

--- a/cloudops/templates/devopsguru.yaml
+++ b/cloudops/templates/devopsguru.yaml
@@ -16,7 +16,7 @@ Parameters:
     MinLength: 36
     MaxLength: 1024
     AllowedPattern: ^arn:aws[a-z0-9-]*:sns:[a-z0-9-]+:\d{12}:[^:]+$
-    Description: The ARN of an Amazon Simple Notification Service topic [required]
+    Description: The Amazon SNS topic ARN for alert [required]
 
 Resources:
   # Service-linked Role

--- a/cloudops/templates/ssm.yaml
+++ b/cloudops/templates/ssm.yaml
@@ -98,7 +98,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -115,7 +115,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -741,7 +741,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -787,7 +787,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -836,7 +836,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -878,7 +878,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -904,7 +904,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ssm-command
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/cloudops/templates/synthetics-api.yaml
+++ b/cloudops/templates/synthetics-api.yaml
@@ -81,9 +81,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -364,7 +366,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -381,7 +383,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/cloudops/templates/synthetics-heartbeat.yaml
+++ b/cloudops/templates/synthetics-heartbeat.yaml
@@ -69,9 +69,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -393,7 +395,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -410,7 +412,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/cloudops/templates/template.yaml
+++ b/cloudops/templates/template.yaml
@@ -126,9 +126,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -323,7 +325,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -340,7 +342,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/edge/templates/cloudfront.yaml
+++ b/edge/templates/cloudfront.yaml
@@ -260,9 +260,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -352,7 +354,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -369,7 +371,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/edge/templates/realtime-dashboard.yaml
+++ b/edge/templates/realtime-dashboard.yaml
@@ -115,9 +115,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -148,7 +150,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -165,7 +167,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${LogicalName}
       Tags:
@@ -417,7 +419,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis-data-streams
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref LogicalName
@@ -598,7 +600,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref LogicalName
@@ -681,7 +683,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-kinesis-data-firehose
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref LogicalName
@@ -848,7 +850,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-elasticsearch
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref LogicalName
@@ -888,7 +890,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -1002,7 +1004,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref LogicalName

--- a/edge/templates/realtime-dashboard.yaml
+++ b/edge/templates/realtime-dashboard.yaml
@@ -600,6 +600,7 @@ Resources:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
         SemanticVersion: 2.2.8
       Parameters:
+        AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref LogicalName
         SNSTopicArn: !If
           - CreateSNSForAlert
@@ -1003,6 +1004,7 @@ Resources:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
         SemanticVersion: 2.2.8
       Parameters:
+        AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref LogicalName
         SNSTopicArn: !If
           - CreateSNSForAlert

--- a/edge/templates/waf.yaml
+++ b/edge/templates/waf.yaml
@@ -70,7 +70,7 @@ Resources:
       Rules: 
         - Name: AWSManagedRulesKnownBadInputsRuleSet
           OverrideAction:
-            Count: {}
+            None: {}
           Priority: 0
           Statement: 
             # Restrict log4j2 message lookup (CWE-117)
@@ -84,7 +84,7 @@ Resources:
             SampledRequestsEnabled: false
         - Name: AWSManagedRulesCommonRuleSet
           OverrideAction:
-            Count: {}
+            None: {}
           Priority: 1
           Statement: 
             ManagedRuleGroupStatement: 
@@ -96,7 +96,7 @@ Resources:
             SampledRequestsEnabled: false
         - Name: AWSManagedRulesAdminProtectionRuleSet
           OverrideAction:
-            Count: {}
+            None: {}
           Priority: 2
           Statement: 
             ManagedRuleGroupStatement: 
@@ -108,7 +108,7 @@ Resources:
             SampledRequestsEnabled: false
         - Name: AWSManagedRulesAmazonIpReputationList
           OverrideAction:
-            Count: {}
+            None: {}
           Priority: 3
           Statement: 
             ManagedRuleGroupStatement: 

--- a/euc/templates/appstream.yaml
+++ b/euc/templates/appstream.yaml
@@ -91,9 +91,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -349,7 +351,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-appstream
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !Ref SNSForDeploymentArn
       Parameters:

--- a/euc/templates/template.yaml
+++ b/euc/templates/template.yaml
@@ -263,9 +263,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -320,7 +322,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -363,7 +365,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -563,7 +565,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -580,7 +582,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -755,7 +757,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-transitgateway-attachment
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/euc/templates/workspaces.yaml
+++ b/euc/templates/workspaces.yaml
@@ -82,9 +82,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -137,7 +139,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-workspaces
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !Ref SNSForDeploymentArn
       Parameters:

--- a/global/templates/costexplorer.yaml
+++ b/global/templates/costexplorer.yaml
@@ -28,7 +28,7 @@ Parameters:
   SNSForAlertArn:
     Type: String
     AllowedPattern: .+
-    Description: The ARN of an Amazon SNS topic [required] 
+    Description: The Amazon SNS topic ARN for alert [required] 
 
 Conditions:
   CreateAnomalyMonitor: !Not [ !Equals [ !Ref SNSForAlertArn, '' ] ]

--- a/global/templates/template.yaml
+++ b/global/templates/template.yaml
@@ -122,6 +122,7 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   Environment:
     Type: String
     Default: production
@@ -210,7 +211,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Alert-createdby-${AWS::StackName}
       Tags:
@@ -344,7 +345,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-acm
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref AWS::StackName
@@ -660,7 +661,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref AWS::StackName

--- a/global/templates/template.yaml
+++ b/global/templates/template.yaml
@@ -662,6 +662,7 @@ Resources:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
         SemanticVersion: 2.2.8
       Parameters:
+        AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref AWS::StackName
         SNSTopicArn: !GetAtt SNSForAlert.Outputs.SNSTopicArn
         MetricFilterPattern: ''

--- a/identity/templates/microsoftad.yaml
+++ b/identity/templates/microsoftad.yaml
@@ -113,10 +113,12 @@ Parameters:
     Description: The VPC id [required]
   SNSForAlertArn:
     Type: String
-    Default: ''   
+    Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   LogicalName:
     Type: String
     Default: MicrosoftAD
@@ -154,7 +156,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -188,7 +190,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -222,7 +224,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -256,7 +258,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -273,7 +275,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -477,7 +479,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-directoryservice
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -503,7 +505,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-directoryservice
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/media/templates/mediaconnect.yaml
+++ b/media/templates/mediaconnect.yaml
@@ -299,10 +299,12 @@ Parameters:
     Description: Source port for SRT-caller protocol [srt-caller]
   SNSForAlertArn:
     Type: String
-    Default: '' 
+    Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -347,7 +349,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -364,7 +366,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -634,7 +636,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-mediaconnect-source
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/media/templates/mediaconvert.yaml
+++ b/media/templates/mediaconvert.yaml
@@ -13,6 +13,11 @@ Metadata:
           - Name
           - StatusUpdateInterval
       - Label: 
+          default: 'Notification Configuration'
+        Parameters: 
+          - SNSForAlertArn
+          - SNSForDeploymentArn
+      - Label: 
           default: 'Tag Configuration'
         Parameters: 
           - LogicalName
@@ -57,6 +62,14 @@ Parameters:
       - 540
       - 600
     Description: How often MediaConvert sends STATUS_UPDATE events to Amazon CloudWatch Events [required]
+  SNSForAlertArn:
+    Type: String
+    Default: ''
+    Description: The Amazon SNS topic ARN for alert
+  SNSForDeploymentArn:
+    Type: String
+    Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   LogicalName:
     Type: String
     Default: MediaConvert
@@ -78,7 +91,42 @@ Parameters:
     Default: aws-cloudformation-templates 
     AllowedPattern: .+
 
+Conditions:
+  CreateSNSForAlert: !Equals [ !Ref SNSForAlertArn, '']
+  CreateSNSForDeployment: !Equals [ !Ref SNSForDeploymentArn, '']
+
 Resources:
+  # Nested Stack
+  SNSForAlert:
+    Condition: CreateSNSForAlert
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 2.2.9
+      NotificationARNs:
+        - !If
+          - CreateSNSForDeployment
+          - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
+          - !Ref SNSForDeploymentArn
+      Parameters:
+        TopicName: !Sub Alert-createdby-${AWS::StackName}
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
+  SNSForDeployment:
+    Condition: CreateSNSForDeployment
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 2.2.9
+      Parameters:
+        TopicName: !Sub Deployment-createdby-${AWS::StackName}
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
+  # IAM Role
   IAMRoleForMediaConvert:
     Type: AWS::IAM::Role
     Properties:
@@ -423,6 +471,30 @@ Resources:
             DenoiseFilter: DISABLED
             TimecodeSource: EMBEDDED
       StatusUpdateInterval: !Sub SECONDS_${StatusUpdateInterval}
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
+  # CloudWatch
+  CloudWatchAlarmMediaConvert:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-mediaconvert
+        SemanticVersion: 2.2.9
+      NotificationARNs: 
+        - !If
+          - CreateSNSForDeployment
+          - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
+          - !Ref SNSForDeploymentArn
+      Parameters:
+        CustomAlarmName: !Ref AWS::StackName
+        SNSTopicArn: !If
+          - CreateSNSForAlert
+          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
+          - !Ref SNSForAlertArn
+        Environment: !Ref Environment
+        TagKey: !Ref TagKey
+        TagValue: !Ref TagValue
       Tags:
         environment: !Ref Environment
         createdby: !Ref TagValue

--- a/media/templates/medialive.yaml
+++ b/media/templates/medialive.yaml
@@ -225,10 +225,12 @@ Parameters:
     Description: Output video width, in pixels [required]
   SNSForAlertArn:
     Type: String
-    Default: '' 
+    Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   LogicalName:
     Type: String
     Default: MediaLive
@@ -278,7 +280,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -295,7 +297,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -875,7 +877,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-medialive
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -902,7 +904,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-medialive
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -929,7 +931,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-elementallink
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -955,7 +957,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-elementallink
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/media/templates/mediastore.yaml
+++ b/media/templates/mediastore.yaml
@@ -42,9 +42,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   LogicalName:
     Type: String
     Default: MediaStore
@@ -79,7 +81,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -96,7 +98,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -187,7 +189,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-mediastore
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         CustomAlarmName: !Ref AWS::StackName
         ContainerName: !Ref MediaStore

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -76,6 +76,68 @@ Properties:
   TimeoutInMinutes: Integer
 ```
 
+## Amplify
+
+The template creates the following alarms.
+
+| Namespace | MetricName | AppId | Threshold |
+| --- | --- | --- | --- |
+| AWS/AmplifyHosting | **5xxErrors** | `AppId` | At least once a minute |
+
+You can provide optional parameters as follows.
+
+| Name | Type | Default | Required | Details | 
+| --- | --- | --- | --- | --- |
+| `AppId` | String | | ○ | The app id |
+| `CustomAlarmName` | String | | | The custom Alram name |
+| `SNSTopicArn` | String | | ○ | The SNS topic ARN |
+| `Environment` | String | production | | The value of `environment` tag |
+| `TagKey` | String | createdby | | A tag key |
+| `TagValue` | String | aws-cloudformation-templates | | A tag value |
+
+### Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+```yaml
+Type: AWS::CloudFormation::Stack
+Properties: 
+  NotificationARNs: 
+    - String
+  Parameters: 
+    AppId: String
+    CustomAlarmName: String
+    SNSTopicArn: String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: 
+    - Tag
+  TemplateURL: !If
+    - Development
+    - https://s3.amazonaws.com/eijikominami-test/aws-cloudformation-templates/monitoring/amplify.yaml
+  TimeoutInMinutes: Integer
+```
+
+```yaml
+Type: AWS::Serverless::Application
+Properties:
+  Location:
+    ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-amplifys
+    SemanticVersion: 2.2.7
+  NotificationARNs: 
+    - String
+  Parameters: 
+    AppId: String
+    CustomAlarmName: String
+    SNSTopicArn: String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: Map
+  TimeoutInMinutes: Integer
+```
+
 ## API Gateway
 
 The template creates the following alarms.
@@ -402,6 +464,67 @@ Properties:
     CustomAlarmName : String
     ProjectName : String
     SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: Map
+  TimeoutInMinutes: Integer
+```
+
+## Config
+
+The template creates the following alarms.
+
+| Namespace | MetricName | Threshold |
+| --- | --- | --- |
+| AWS/Config | **ChangeNotificationsDeliveryFailed** | At least once a minute |
+| AWS/Config | **ConfigHistoryExportFailed** | At least once a minute |
+| AWS/Config | **ConfigSnapshotExportFailed** | At least once a minute |
+
+You can provide optional parameters as follows.
+
+| Name | Type | Default | Required | Details | 
+| --- | --- | --- | --- | --- |
+| `CustomAlarmName` | String | | | The custom Alram name |
+| `SNSTopicArn` | String | | ○ | The SNS topic ARN |
+| `Environment` | String | production | | The value of `environment` tag |
+| `TagKey` | String | createdby | | A tag key |
+| `TagValue` | String | aws-cloudformation-templates | | A tag value |
+
+### Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+```yaml
+Type: AWS::CloudFormation::Stack
+Properties: 
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName: String
+    SNSTopicArn: String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: 
+    - Tag
+  TemplateURL: !If
+    - Development
+    - https://s3.amazonaws.com/eijikominami-test/aws-cloudformation-templates/monitoring/cofig.yaml
+  TimeoutInMinutes: Integer
+```
+
+```yaml
+Type: AWS::Serverless::Application
+Properties:
+  Location:
+    ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-cofig
+    SemanticVersion: 2.2.7
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName: String
+    SNSTopicArn: String
     Environment: String
     TagKey: String
     TagValue: String
@@ -1365,6 +1488,72 @@ Properties:
   TimeoutInMinutes: Integer
 ```
 
+## MediaConvert
+
+The template creates the following alarms.
+
+| Namespace | MetricName | Operation | Threshold |
+| --- | --- | --- | --- |
+| AWS/MediaConvert | **Errors** | CreateJob | At least once a minute | 
+| AWS/MediaConvert | **Errors** | GetJob | At least once a minute | 
+| AWS/MediaConvert | **Errors** | GetQueue | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListJobs | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListJobTemplates | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListPresets | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListQueues | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListTagsForResource | At least once a minute | 
+
+You can provide optional parameters as follows.
+
+| Name | Type | Default | Required | Details | 
+| --- | --- | --- | --- | --- |
+| `CustomAlarmName` | String | | | The custom Alram name |
+| `SNSTopicArn` | String | | ○ | The SNS topic ARN |
+| `Environment` | String | production | | The value of `environment` tag |
+| `TagKey` | String | createdby | | A tag key |
+| `TagValue` | String | aws-cloudformation-templates | | A tag value |
+
+### Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+```yaml
+Type: AWS::CloudFormation::Stack
+Properties: 
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName : String
+    SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: 
+    - Tag
+  TemplateURL: !If
+    - Development
+    - https://s3.amazonaws.com/eijikominami-test/aws-cloudformation-templates/monitoring/mediaconvert.yaml
+  TimeoutInMinutes: Integer
+```
+
+```yaml
+Type: AWS::Serverless::Application
+Properties:
+  Location:
+    ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-mediaconvert
+    SemanticVersion: 2.2.7
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName : String
+    SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: Map
+  TimeoutInMinutes: Integer
+```
+
 ## MediaLive
 
 The template creates the following alarms.
@@ -1557,6 +1746,68 @@ Properties:
   Parameters:
     AlarmLevel: String 
     CustomAlarmName : String
+    SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: Map
+  TimeoutInMinutes: Integer
+```
+
+## Route 53 Resolver
+
+The template creates the following alarms.
+
+| Namespace | MetricName | EndpointId | Threshold |
+| --- | --- | --- | --- |
+| AWS/Route53Resolver | **EndpointUnhealthyENICount** | `EndpointId` | At least once a minute |
+
+You can provide optional parameters as follows.
+
+| Name | Type | Default | Required | Details | 
+| --- | --- | --- | --- | --- |
+| `CustomAlarmName` | String | | | The custom Alram name |
+| `EndpointId` | String | | ○ | The endpoint ID |
+| `SNSTopicArn` | String | | ○ | The SNS topic ARN |
+| `Environment` | String | production | | The value of `environment` tag |
+| `TagKey` | String | createdby | | A tag key |
+| `TagValue` | String | aws-cloudformation-templates | | A tag value |
+
+### Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+```yaml
+Type: AWS::CloudFormation::Stack
+Properties: 
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName : String
+    EndpointId: String
+    SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: 
+    - Tag
+  TemplateURL: !If
+    - Development
+    - https://s3.amazonaws.com/eijikominami-test/aws-cloudformation-templates/monitoring/route53-resolver.yaml
+  TimeoutInMinutes: Integer
+```
+
+```yaml
+Type: AWS::Serverless::Application
+Properties:
+  Location:
+    ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-route53-resolver
+    SemanticVersion: 2.2.7
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName : String
+    EndpointId: String
     SNSTopicArn : String
     Environment: String
     TagKey: String

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -1643,6 +1643,9 @@ Properties:
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | カスタムアラーム名 |
 | `SNSTopicArn` | String | | ○ | SNSトピックのARN |
+| `Environment` | String | production | | The value of `environment` tag |
+| `TagKey` | String | createdby | | A tag key |
+| `TagValue` | String | aws-cloudformation-templates | | A tag value |
 
 ### Syntax
 

--- a/monitoring/README_JP.md
+++ b/monitoring/README_JP.md
@@ -76,6 +76,68 @@ Properties:
   TimeoutInMinutes: Integer
 ```
 
+## Amplify
+
+このテンプレートは、以下のアラームを作成します。
+
+| ネームスペース | メトリクス | AppID | 閾値 |
+| --- | --- | --- | --- |
+| AWS/AmplifyHosting | **5xxErrors** | `AppId` | 1分間に1回以上 |
+
+以下のパラメータを指定できます。
+
+| パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
+| --- | --- | --- | --- | --- |
+| `AppId` | String | | ○ | アプリ ID |
+| `CustomAlarmName` | String | | | カスタムアラーム名 |
+| `SNSTopicArn` | String | | ○ | SNSトピックのARN |
+| `Environment` | String | production | | `environment` タグの値 |
+| `TagKey` | String | createdby | | タグキー |
+| `TagValue` | String | aws-cloudformation-templates | | タグ値 |
+
+### Syntax
+
+AWS CloudFormation テンプレートでこのエンティティを宣言するには、次の構文を使用します。
+
+```yaml
+Type: AWS::CloudFormation::Stack
+Properties: 
+  NotificationARNs: 
+    - String
+  Parameters: 
+    AppId: String
+    CustomAlarmName: String
+    SNSTopicArn: String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: 
+    - Tag
+  TemplateURL: !If
+    - Development
+    - https://s3.amazonaws.com/eijikominami-test/aws-cloudformation-templates/monitoring/amplify.yaml
+  TimeoutInMinutes: Integer
+```
+
+```yaml
+Type: AWS::Serverless::Application
+Properties:
+  Location:
+    ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-amplify
+    SemanticVersion: 2.2.7
+  NotificationARNs: 
+    - String
+  Parameters: 
+    AppId: String
+    CustomAlarmName: String
+    SNSTopicArn: String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: Map
+  TimeoutInMinutes: Integer
+```
+
 ## API Gateway
 
 このテンプレートは、以下のアラームを作成します。
@@ -401,6 +463,67 @@ Properties:
     CustomAlarmName : String
     ProjectName : String
     SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: Map
+  TimeoutInMinutes: Integer
+```
+
+## Config
+
+このテンプレートは、以下のアラームを作成します。
+
+| ネームスペース | メトリクス | 閾値 |
+| --- | --- | --- |
+| AWS/Config | **ChangeNotificationsDeliveryFailed** | 1分間に1回以上 |
+| AWS/Config | **ConfigHistoryExportFailed** | 1分間に1回以上 |
+| AWS/Config | **ConfigSnapshotExportFailed** | 1分間に1回以上 |
+
+以下のパラメータを指定できます。
+
+| パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
+| --- | --- | --- | --- | --- |
+| `CustomAlarmName` | String | | | カスタムアラーム名 |
+| `SNSTopicArn` | String | | ○ | SNSトピックのARN |
+| `Environment` | String | production | | `environment` タグの値 |
+| `TagKey` | String | createdby | | タグキー |
+| `TagValue` | String | aws-cloudformation-templates | | タグ値 |
+
+### Syntax
+
+AWS CloudFormation テンプレートでこのエンティティを宣言するには、次の構文を使用します。
+
+```yaml
+Type: AWS::CloudFormation::Stack
+Properties: 
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName: String
+    SNSTopicArn: String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: 
+    - Tag
+  TemplateURL: !If
+    - Development
+    - https://s3.amazonaws.com/eijikominami-test/aws-cloudformation-templates/monitoring/config.yaml
+  TimeoutInMinutes: Integer
+```
+
+```yaml
+Type: AWS::Serverless::Application
+Properties:
+  Location:
+    ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-config
+    SemanticVersion: 2.2.7
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName: String
+    SNSTopicArn: String
     Environment: String
     TagKey: String
     TagValue: String
@@ -1366,6 +1489,72 @@ Properties:
   TimeoutInMinutes: Integer
 ```
 
+## MediaConvert
+
+このテンプレートは、以下のアラームを作成します。
+
+| ネームスペース | メトリクス | Operation | 閾値 |
+| --- | --- | --- | --- | --- |
+| AWS/MediaConvert | **Errors** | CreateJob | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | GetJob | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | GetQueue | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListJobs | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListJobTemplates | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListPresets | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListQueues | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListTagsForResource | 1分間に1回以上 | 
+
+以下のパラメータを指定できます。
+
+| パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
+| --- | --- | --- | --- | --- |
+| `CustomAlarmName` | String | | | カスタムアラーム名 |
+| `SNSTopicArn` | String | | ○ | SNSトピックのARN |
+| `Environment` | String | production | | `environment` タグの値 |
+| `TagKey` | String | createdby | | タグキー |
+| `TagValue` | String | aws-cloudformation-templates | | タグ値 |
+
+### Syntax
+
+AWS CloudFormation テンプレートでこのエンティティを宣言するには、次の構文を使用します。
+
+```yaml
+Type: AWS::CloudFormation::Stack
+Properties: 
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName : String
+    SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: 
+    - Tag
+  TemplateURL: !If
+    - Development
+    - https://s3.amazonaws.com/eijikominami-test/aws-cloudformation-templates/monitoring/mediaconvert.yaml
+  TimeoutInMinutes: Integer
+```
+
+```yaml
+Type: AWS::Serverless::Application
+Properties:
+  Location:
+    ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-mediaconvert
+    SemanticVersion: 2.2.7
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName : String
+    SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: Map
+  TimeoutInMinutes: Integer
+```
+
 ## MediaLive
 
 このテンプレートは、以下のアラームを作成します。
@@ -1556,6 +1745,69 @@ Properties:
   Parameters: 
     AlarmLevel: String
     CustomAlarmName : String
+    SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: Map
+  TimeoutInMinutes: Integer
+```
+
+## Route 53 Resolver
+
+このテンプレートは、以下のアラームを作成します。
+
+| ネームスペース | メトリクス | エンドポイント ID | 閾値 |
+| --- | --- | --- | --- |
+| AWS/Route53Resolver | **EndpointUnhealthyENICount** | `EndpointId` | 1分間に1回以上 |
+
+## パラメータ
+
+以下のパラメータを指定できます。
+
+| パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
+| --- | --- | --- | --- | --- |
+| `CustomAlarmName` | String | | | カスタムアラーム名 |
+| `EndpointId` | String | | ○ | エンドポイント ID |
+| `SNSTopicArn` | String | | ○ | SNSトピックのARN |
+| `Environment` | String | production | | `environment` タグの値 |
+| `TagKey` | String | createdby | | タグキー |
+
+### Syntax
+
+AWS CloudFormation テンプレートでこのエンティティを宣言するには、次の構文を使用します。
+
+```yaml
+Type: AWS::CloudFormation::Stack
+Properties: 
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName : String
+    EndpointId: String
+    SNSTopicArn : String
+    Environment: String
+    TagKey: String
+    TagValue: String
+  Tags: 
+    - Tag
+  TemplateURL: !If
+    - Development
+    - https://s3.amazonaws.com/eijikominami-test/aws-cloudformation-templates/monitoring/route53-resolver.yaml
+  TimeoutInMinutes: Integer
+```
+
+```yaml
+Type: AWS::Serverless::Application
+Properties:
+  Location:
+    ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-route53-resolver
+    SemanticVersion: 2.2.7
+  NotificationARNs: 
+    - String
+  Parameters: 
+    CustomAlarmName : String
+    EndpointId: String
     SNSTopicArn : String
     Environment: String
     TagKey: String

--- a/monitoring/readme/cloudwatch-alarm-about-amplify.md
+++ b/monitoring/readme/cloudwatch-alarm-about-amplify.md
@@ -1,0 +1,53 @@
+Please scroll down for the Japanese version. / **日本語の説明は下にあります。**
+
+# cloudwatch-alarm-about-amplify(en)
+
+cloudwatch-alarm-about-amplify creates Amazon CloudWatch Alarm about Amplify.
+
+## CloudWatch Alarm
+
+The template creates the following alarms.
+
+| Namespace | MetricName | AppId | Threshold |
+| --- | --- | --- | --- |
+| AWS/AmplifyHosting | **5xxErrors** | `AppId` | At least once a minute |
+
+## Parameters
+
+You can provide optional parameters as follows.
+
+| Name | Type | Default | Required | Details | 
+| --- | --- | --- | --- | --- |
+| `AppId` | String | | ○ | The app id |
+| `CustomAlarmName` | String | | | The custom Alram name |
+| `SNSTopicArn` | String | | ○ | The SNS topic ARN |
+| `Environment` | String | production | | The value of `environment` tag |
+| `TagKey` | String | createdby | | A tag key |
+| `TagValue` | String | aws-cloudformation-templates | | A tag value |
+
+---------------------------------------
+
+# cloudwatch-alarm-about-amplify(ja)
+
+cloudwatch-alarm-about-amplify は、Amplify に関する Amazon CloudWatch アラームを作成します。
+
+## CloudWatch アラーム
+
+このテンプレートは、以下のアラームを作成します。
+
+| ネームスペース | メトリクス | AppID | 閾値 |
+| --- | --- | --- | --- |
+| AWS/AmplifyHosting | **5xxErrors** | `AppId` | 1分間に1回以上 |
+
+## パラメータ
+
+以下のパラメータを指定できます。
+
+| パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
+| --- | --- | --- | --- | --- |
+| `AppId` | String | | ○ | アプリ ID |
+| `CustomAlarmName` | String | | | カスタムアラーム名 |
+| `SNSTopicArn` | String | | ○ | SNSトピックのARN |
+| `Environment` | String | production | | `environment` タグの値 |
+| `TagKey` | String | createdby | | タグキー |
+| `TagValue` | String | aws-cloudformation-templates | | タグ値 |

--- a/monitoring/readme/cloudwatch-alarm-about-config.md
+++ b/monitoring/readme/cloudwatch-alarm-about-config.md
@@ -1,16 +1,18 @@
 Please scroll down for the Japanese version. / **日本語の説明は下にあります。**
 
-# cloudwatch-alarm-about-vpn(en)
+# cloudwatch-alarm-about-config(en)
 
-cloudwatch-alarm-about-vpn creates Amazon CloudWatch Alarm about AWS Site-to-Site VPN.
+cloudwatch-alarm-about-config creates Amazon CloudWatch Alarm about AWS Config.
 
 ## CloudWatch Alarm
 
 The template creates the following alarms.
 
-| Namespace | MetricName | VPNId | Threshold |
+| Namespace | MetricName | Threshold |
 | --- | --- | --- |
-| AWS/VPN | **TunnelState** | `VpnId` | 0 |
+| AWS/Config | **ChangeNotificationsDeliveryFailed** | At least once a minute |
+| AWS/Config | **ConfigHistoryExportFailed** | At least once a minute |
+| AWS/Config | **ConfigSnapshotExportFailed** | At least once a minute |
 
 ## Parameters
 
@@ -19,7 +21,6 @@ You can provide optional parameters as follows.
 | Name | Type | Default | Required | Details | 
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | The custom Alram name |
-| `VpnId` | String | | ○ | The VPN ID |
 | `SNSTopicArn` | String | | ○ | The SNS topic ARN |
 | `Environment` | String | production | | The value of `environment` tag |
 | `TagKey` | String | createdby | | A tag key |
@@ -27,17 +28,19 @@ You can provide optional parameters as follows.
 
 ---------------------------------------
 
-# cloudwatch-alarm-about-vpn(ja)
+# cloudwatch-alarm-about-natgateway(ja)
 
-cloudwatch-alarm-about-vpn は、Amazon Site-to-Site VPN に関する Amazon CloudWatch アラームを作成します。
+cloudwatch-alarm-about-config は、AWS Config に関する Amazon CloudWatch アラームを作成します。
 
 ## CloudWatch アラーム
 
 このテンプレートは、以下のアラームを作成します。
 
-| ネームスペース | メトリクス | VPN ID | 閾値 |
+| ネームスペース | メトリクス | 閾値 |
 | --- | --- | --- |
-| AWS/VPN | **TunnelState** | `VpnId` | 0 |
+| AWS/Config | **ChangeNotificationsDeliveryFailed** | 1分間に1回以上 |
+| AWS/Config | **ConfigHistoryExportFailed** | 1分間に1回以上 |
+| AWS/Config | **ConfigSnapshotExportFailed** | 1分間に1回以上 |
 
 ## パラメータ
 
@@ -46,7 +49,6 @@ cloudwatch-alarm-about-vpn は、Amazon Site-to-Site VPN に関する Amazon Clo
 | パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | カスタムアラーム名 |
-| `VpnId` | String | | ○ | VPN ID |
 | `SNSTopicArn` | String | | ○ | SNSトピックのARN |
 | `Environment` | String | production | | `environment` タグの値 |
 | `TagKey` | String | createdby | | タグキー |

--- a/monitoring/readme/cloudwatch-alarm-about-mediaconvert.md
+++ b/monitoring/readme/cloudwatch-alarm-about-mediaconvert.md
@@ -1,0 +1,65 @@
+Please scroll down for the Japanese version. / **日本語の説明は下にあります。**
+
+# cloudwatch-alarm-about-mediaconvert(en)
+
+cloudwatch-alarm-about-mediaconvert creates Amazon CloudWatch Alarm about AWS Elemental MediaConvert.
+
+## CloudWatch Alarm
+
+The template creates the following alarms.
+
+| Namespace | MetricName | Operation | Threshold |
+| --- | --- | --- | --- |
+| AWS/MediaConvert | **Errors** | CreateJob | At least once a minute | 
+| AWS/MediaConvert | **Errors** | GetJob | At least once a minute | 
+| AWS/MediaConvert | **Errors** | GetQueue | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListJobs | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListJobTemplates | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListPresets | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListQueues | At least once a minute | 
+| AWS/MediaConvert | **Errors** | ListTagsForResource | At least once a minute | 
+
+## Parameters
+
+You can provide optional parameters as follows.
+
+| Name | Type | Default | Required | Details | 
+| --- | --- | --- | --- | --- |
+| `CustomAlarmName` | String | | | The custom Alram name |
+| `SNSTopicArn` | String | | ○ | The SNS topic ARN |
+| `Environment` | String | production | | The value of `environment` tag |
+| `TagKey` | String | createdby | | A tag key |
+| `TagValue` | String | aws-cloudformation-templates | | A tag value |
+
+---------------------------------------
+
+# cloudwatch-alarm-about-mediaconvert(ja)
+
+cloudwatch-alarm-about-mediaconvert は、 AWS Elemental MediaConvert に関する Amazon CloudWatch アラームを作成します。
+
+## CloudWatch アラーム
+
+このテンプレートは、以下のアラームを作成します。
+
+| ネームスペース | メトリクス | Operation | 閾値 |
+| --- | --- | --- | --- | --- |
+| AWS/MediaConvert | **Errors** | CreateJob | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | GetJob | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | GetQueue | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListJobs | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListJobTemplates | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListPresets | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListQueues | 1分間に1回以上 | 
+| AWS/MediaConvert | **Errors** | ListTagsForResource | 1分間に1回以上 | 
+
+## パラメータ
+
+以下のパラメータを指定できます。
+
+| パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
+| --- | --- | --- | --- | --- |
+| `CustomAlarmName` | String | | | カスタムアラーム名 |
+| `SNSTopicArn` | String | | ○ | SNSトピックのARN |
+| `Environment` | String | production | | `environment` タグの値 |
+| `TagKey` | String | createdby | | タグキー |
+| `TagValue` | String | aws-cloudformation-templates | | タグ値 |

--- a/monitoring/readme/cloudwatch-alarm-about-network-elb.md
+++ b/monitoring/readme/cloudwatch-alarm-about-network-elb.md
@@ -1,17 +1,17 @@
 Please scroll down for the Japanese version. / **日本語の説明は下にあります。**
 
-# cloudwatch-alarm-about-ssm(en)
+# cloudwatch-alarm-about-network-elb(en)
 
-cloudwatch-alarm-about-ssm creates Amazon AWS Systems Manager Run Command.
+cloudwatch-alarm-about-network-elb creates Amazon CloudWatch Alarm about Network Load Balancer.
 
 ## CloudWatch Alarm
 
 The template creates the following alarms.
 
-| Namespace | MetricName | Threshold |
+| Namespace | MetricName | TargetGroup | LoadBalancer | Threshold |
 | --- | --- | --- | --- | --- |
-| AWS/SSM-RunCommand | `CommandsDeliveryTimedOut` | At least once a minute | 
-| AWS/SSM-RunCommand | `CommandsFailed` | At least once a minute | 
+| AWS/NetworkELB | **UnHealthyHostCount** | `TargetGroup` | `LoadBalancer` | At least once a minute | 
+| AWS/NetworkELB | **PortAllocationErrorCount** | `TargetGroup` | `LoadBalancer` | At least once a minute | 
 
 ## Parameters
 
@@ -20,25 +20,26 @@ You can provide optional parameters as follows.
 | Name | Type | Default | Required | Details | 
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | The custom Alram name |
-| `SNSTopicArn` | String | | ○ | The SNS topic ARN |
+| `TargetGroup` | String | | ○ | The target group id |
+| `LoadBalancer` | String | | ○ | The load balancer name |
 | `Environment` | String | production | | The value of `environment` tag |
 | `TagKey` | String | createdby | | A tag key |
 | `TagValue` | String | aws-cloudformation-templates | | A tag value |
 
 ---------------------------------------
 
-# cloudwatch-alarm-about-ssm(ja)
+# cloudwatch-alarm-about-network-elb(ja)
 
-cloudwatch-alarm-about-ssm は、 Amazon AWS Systems Manager Run Command に関する Amazon CloudWatch アラームを作成します。
+cloudwatch-alarm-about-network-elb Network Load Balancer に関する Amazon CloudWatch アラームを作成します。
 
 ## CloudWatch アラーム
 
 このテンプレートは、以下のアラームを作成します。
 
-| ネームスペース | メトリクス | 閾値 |
+| ネームスペース | メトリクス | TargetGroup | LoadBalancer | 閾値 |
 | --- | --- | --- | --- | --- |
-| AWS/SSM-RunCommand | `CommandsDeliveryTimedOut` | 1分間に1回以上 | 
-| AWS/SSM-RunCommand | `CommandsFailed` | 1分間に1回以上 | 
+| AWS/NetworkELB | **UnHealthyHostCount** | `TargetGroup` | `LoadBalancer` | 1分間に1回以上 | 
+| AWS/NetworkELB | **PortAllocationErrorCount** | `TargetGroup` | `LoadBalancer` | 1分間に1回以上 | 
 
 ## パラメータ
 
@@ -47,7 +48,8 @@ cloudwatch-alarm-about-ssm は、 Amazon AWS Systems Manager Run Command に関�
 | パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | カスタムアラーム名 |
-| `SNSTopicArn` | String | | ○ | SNSトピックのARN |
+| `TargetGroup` | String | | ○ | ターゲットグループID |
+| `LoadBalancer` | String | | ○ | ロードバランサー名 |
 | `Environment` | String | production | | `environment` タグの値 |
 | `TagKey` | String | createdby | | タグキー |
 | `TagValue` | String | aws-cloudformation-templates | | タグ値 |

--- a/monitoring/readme/cloudwatch-alarm-about-route53-resolver.md
+++ b/monitoring/readme/cloudwatch-alarm-about-route53-resolver.md
@@ -1,16 +1,16 @@
 Please scroll down for the Japanese version. / **日本語の説明は下にあります。**
 
-# cloudwatch-alarm-about-vpn(en)
+# cloudwatch-alarm-about-route53-resolver(en)
 
-cloudwatch-alarm-about-vpn creates Amazon CloudWatch Alarm about AWS Site-to-Site VPN.
+cloudwatch-alarm-about-route53-resolver creates Amazon CloudWatch Alarm about Route 53 Resolver.
 
 ## CloudWatch Alarm
 
 The template creates the following alarms.
 
-| Namespace | MetricName | VPNId | Threshold |
-| --- | --- | --- |
-| AWS/VPN | **TunnelState** | `VpnId` | 0 |
+| Namespace | MetricName | EndpointId | Threshold |
+| --- | --- | --- | --- |
+| AWS/Route53Resolver | **EndpointUnhealthyENICount** | `EndpointId` | At least once a minute |
 
 ## Parameters
 
@@ -19,7 +19,7 @@ You can provide optional parameters as follows.
 | Name | Type | Default | Required | Details | 
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | The custom Alram name |
-| `VpnId` | String | | ○ | The VPN ID |
+| `EndpointId` | String | | ○ | The endpoint ID |
 | `SNSTopicArn` | String | | ○ | The SNS topic ARN |
 | `Environment` | String | production | | The value of `environment` tag |
 | `TagKey` | String | createdby | | A tag key |
@@ -27,17 +27,17 @@ You can provide optional parameters as follows.
 
 ---------------------------------------
 
-# cloudwatch-alarm-about-vpn(ja)
+# cloudwatch-alarm-about-route53-resolver(ja)
 
-cloudwatch-alarm-about-vpn は、Amazon Site-to-Site VPN に関する Amazon CloudWatch アラームを作成します。
+cloudwatch-alarm-about-route53-resolver は、Route 53 Resolver に関する Amazon CloudWatch アラームを作成します。
 
 ## CloudWatch アラーム
 
 このテンプレートは、以下のアラームを作成します。
 
-| ネームスペース | メトリクス | VPN ID | 閾値 |
-| --- | --- | --- |
-| AWS/VPN | **TunnelState** | `VpnId` | 0 |
+| ネームスペース | メトリクス | エンドポイント ID | 閾値 |
+| --- | --- | --- | --- |
+| AWS/Route53Resolver | **EndpointUnhealthyENICount** | `EndpointId` | 1分間に1回以上 |
 
 ## パラメータ
 
@@ -46,7 +46,7 @@ cloudwatch-alarm-about-vpn は、Amazon Site-to-Site VPN に関する Amazon Clo
 | パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | カスタムアラーム名 |
-| `VpnId` | String | | ○ | VPN ID |
+| `EndpointId` | String | | ○ | エンドポイント ID |
 | `SNSTopicArn` | String | | ○ | SNSトピックのARN |
 | `Environment` | String | production | | `environment` タグの値 |
 | `TagKey` | String | createdby | | タグキー |

--- a/monitoring/readme/cloudwatch-alarm-about-transitgateway-attachment.md
+++ b/monitoring/readme/cloudwatch-alarm-about-transitgateway-attachment.md
@@ -50,3 +50,6 @@ cloudwatch-alarm-about-transitgateway-attachment は、AWS Transit Gateway ア�
 | `SNSTopicArn` | String | | ○ | SNSトピックのARN |
 | `TransitGatewayId` | String | | ○ | Transit Gateway の ID |
 | `TransitGatewayAttachmentId` | String | | ○ | Transit Gateway アタッチメントの ID |
+| `Environment` | String | production | | `environment` タグの値 |
+| `TagKey` | String | createdby | | タグキー |
+| `TagValue` | String | aws-cloudformation-templates | | タグ値 |

--- a/monitoring/readme/cloudwatch-alarm-about-transitgateway.md
+++ b/monitoring/readme/cloudwatch-alarm-about-transitgateway.md
@@ -48,3 +48,6 @@ cloudwatch-alarm-about-transitgateway は、AWS Transit Gateway に関する Ama
 | `CustomAlarmName` | String | | | カスタムアラーム名 |
 | `SNSTopicArn` | String | | ○ | SNSトピックのARN |
 | `TransitGatewayId` | String | | ○ | Transit Gateway の ID |
+| `Environment` | String | production | | `environment` タグの値 |
+| `TagKey` | String | createdby | | タグキー |
+| `TagValue` | String | aws-cloudformation-templates | | タグ値 |

--- a/monitoring/readme/cloudwatch-alarm-about-vpn.md
+++ b/monitoring/readme/cloudwatch-alarm-about-vpn.md
@@ -1,16 +1,16 @@
 Please scroll down for the Japanese version. / **日本語の説明は下にあります。**
 
-# cloudwatch-alarm-about-appstream(en)
+# cloudwatch-alarm-about-vpn(en)
 
-cloudwatch-alarm-about-appstream creates Amazon CloudWatch Alarm about Amazon AppStream.
+cloudwatch-alarm-about-vpn creates Amazon CloudWatch Alarm about AWS Site-to-Site VPN.
 
 ## CloudWatch Alarm
 
 The template creates the following alarms.
 
-| Namespace | MetricName | Fleet | Threshold |
-| --- | --- | --- | --- |
-| AWS/AppStream | **InsufficientConcurrencyLimitError** | `Fleet` | At least once a minute |
+| Namespace | MetricName | DirectoryId | Threshold |
+| --- | --- | --- |
+| AWS/VPN | **TunnelState** | `VpnId` | 0 |
 
 ## Parameters
 
@@ -19,7 +19,7 @@ You can provide optional parameters as follows.
 | Name | Type | Default | Required | Details | 
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | The custom Alram name |
-| `Fleet` | String | | ○ | The name of the AppStream Fleet |
+| `VpnId` | String | | ○ | The VPN ID |
 | `SNSTopicArn` | String | | ○ | The SNS topic ARN |
 | `Environment` | String | production | | The value of `environment` tag |
 | `TagKey` | String | createdby | | A tag key |
@@ -27,17 +27,17 @@ You can provide optional parameters as follows.
 
 ---------------------------------------
 
-# cloudwatch-alarm-about-appstream(ja)
+# cloudwatch-alarm-about-vpn(ja)
 
-cloudwatch-alarm-about-appstream は、Amazon AppStream アタッチメントに関する Amazon CloudWatch アラームを作成します。
+cloudwatch-alarm-about-vpn は、Amazon Site-to-Site VPN に関する Amazon CloudWatch アラームを作成します。
 
 ## CloudWatch アラーム
 
 このテンプレートは、以下のアラームを作成します。
 
-| ネームスペース | メトリクス | Fleet 名 | 閾値 |
-| --- | --- | --- | --- |
-| AWS/AppStream | **InsufficientConcurrencyLimitError** | `Fleet` | 1分間に1回以上 |
+| ネームスペース | メトリクス | ディレクトリ ID | 閾値 |
+| --- | --- | --- |
+| AWS/VPN | **TunnelState** | `VpnId` | 0 |
 
 ## パラメータ
 
@@ -46,7 +46,7 @@ cloudwatch-alarm-about-appstream は、Amazon AppStream アタッチメントに
 | パラメータ | タイプ | デフォルト値 | 必須 | 内容 | 
 | --- | --- | --- | --- | --- |
 | `CustomAlarmName` | String | | | カスタムアラーム名 |
-| `Fleet` | String | | ○ | AppSream Fleet 名 |
+| `VpnId` | String | | ○ | VPN ID |
 | `SNSTopicArn` | String | | ○ | SNSトピックのARN |
 | `Environment` | String | production | | `environment` タグの値 |
 | `TagKey` | String | createdby | | タグキー |

--- a/monitoring/readme/cloudwatch-alarm-about-workspaces.md
+++ b/monitoring/readme/cloudwatch-alarm-about-workspaces.md
@@ -48,3 +48,6 @@ cloudwatch-alarm-about-workspaces は、Amazon Workspaces アタッチメント�
 | `CustomAlarmName` | String | | | カスタムアラーム名 |
 | `DirectoryId` | String | | ○ | Workspaces ディレクトリ ID |
 | `SNSTopicArn` | String | | ○ | SNSトピックのARN |
+| `Environment` | String | production | | `environment` タグの値 |
+| `TagKey` | String | createdby | | タグキー |
+| `TagValue` | String | aws-cloudformation-templates | | タグ値 |

--- a/monitoring/sam-app/acm.yaml
+++ b/monitoring/sam-app/acm.yaml
@@ -50,7 +50,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*CertificateManager* (${CustomAlarmName}) の有効期限は残り30日以下です。'
+      AlarmDescription: !Sub '*CertificateManager* (${CustomAlarmName}) の有効期限は残り30日以下です。証明書の更新は、<https://docs.aws.amazon.com/ja_jp/acm/latest/userguide/managed-renewal.html|マネージド証明書の更新> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-CertificateManager-DaysToExpiry-30
@@ -80,7 +80,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*CertificateManager* (${CustomAlarmName}) の有効期限は残り7日以下です。'
+      AlarmDescription: !Sub '*CertificateManager* (${CustomAlarmName}) の有効期限は残り7日以下です。証明書の更新は、<https://docs.aws.amazon.com/ja_jp/acm/latest/userguide/managed-renewal.html|マネージド証明書の更新> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-CertificateManager-DaysToExpiry-7
@@ -110,7 +110,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*CertificateManager* (${CustomAlarmName}) の有効期限は残り1日以下です。'
+      AlarmDescription: !Sub '*CertificateManager* (${CustomAlarmName}) の有効期限は残り1日以下です。証明書の更新は、<https://docs.aws.amazon.com/ja_jp/acm/latest/userguide/managed-renewal.html|マネージド証明書の更新> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-CertificateManager-DaysToExpiry-1

--- a/monitoring/sam-app/amplify.yaml
+++ b/monitoring/sam-app/amplify.yaml
@@ -1,16 +1,16 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: CloudWatch alarm for Amazon Route 53 Resolver
+Description: CloudWatch alarm for AWS Amplify
 
 Parameters:
+  AppId:
+    Type: String
+    AllowedPattern: .+
+    Description: The app id [required]
   CustomAlarmName:
     Type: String
     Default: ''
     Description: The custom Alram name
-  EndpointId:
-    Type: String
-    AllowedPattern: .+
-    Description: The endpoint ID of the Route 53 Resolver [required]  
   SNSTopicArn:
     Type: String
     AllowedPattern: .+
@@ -35,29 +35,29 @@ Conditions:
   CreateCustomAlarmName: !Not [ !Equals [ !Ref CustomAlarmName, '' ] ]
 
 Resources:
-  EndpointUnhealthyENICount:
+  5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: '*Route53 Resolver* に *復旧の必要のある ENI* があります。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/Route53/latest/DeveloperGuide/monitoring-resolver-with-cloudwatch.html|Amazon CloudWatch による Route 53 Resolver エンドポイントのモニタリング> をご覧ください。'
+      AlarmDescription: !Sub '*Amplify* (${AppId}) で *5XXエラー* が発生しています。'
       AlarmName: !If
         - CreateCustomAlarmName
-        - !Sub Warning-${CustomAlarmName}-Route53Resolver-EndpointUnhealthyENICount
-        - Warning-Route53Resolver-EndpointUnhealthyENICount
+        - !Sub Warning-${CustomAlarmName}-Amplify-5xxErrors
+        - Warning-Amplify-5xxErrors
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-        - Name: EndpointId
-          Value: !Ref EndpointId
+        - Name: App
+          Value: !Ref AppId
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
-      MetricName: EndpointUnhealthyENICount
-      Namespace: AWS/Route53Resolver
+      MetricName: 5xxErrors
+      Namespace: AWS/AmplifyHosting
       OKActions:
         - !Ref SNSTopicArn
       Period: 60
-      Statistic: Maximum
+      Statistic: Sum
       Threshold: 1
       TreatMissingData: notBreaching
       Tags: 

--- a/monitoring/sam-app/apigateway.yaml
+++ b/monitoring/sam-app/apigateway.yaml
@@ -62,7 +62,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
-      AlarmDescription: !Sub '*API Gateway* (${ApiName}) の GET メソッドで *4XX エラー* が発生しました。'
+      AlarmDescription: !Sub '*API Gateway* (${ApiName}) の GET メソッドで *4XX エラー* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html|Amazon API Gateway のディメンションとメトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-ApiGateway-${ApiName}-4XX-Error-Occured
@@ -92,7 +92,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*API Gateway* (${ApiName}) の GET メソッドで *5XX エラー* が発生しました。 *内部処理に異常が発生* している可能性があります。'
+      AlarmDescription: !Sub '*API Gateway* (${ApiName}) の GET メソッドで *5XX エラー* が発生しました。 *内部処理に異常が発生* している可能性があります。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html|Amazon API Gateway のディメンションとメトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-ApiGateway-${ApiName}-5XX-Error-Occured
@@ -125,7 +125,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*API Gateway* (${ApiName}) の GET メソッドで *Latencyの値が増加* しています。このエラーが継続する場合は、 *トラフィックの増大* もしくは *内部処理に異常が発生* している可能性があります。'
+      AlarmDescription: !Sub '*API Gateway* (${ApiName}) の GET メソッドで *Latencyの値が増加* しています。このエラーが継続する場合は、 *トラフィックの増大* もしくは *内部処理に異常が発生* している可能性があります。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html|Amazon API Gateway のディメンションとメトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-ApiGateway-${ApiName}-Latency
@@ -157,7 +157,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*API Gateway* (${ApiName}) で *分間リクエスト数がプロビジョニングされたスループット値に近づいています* 。'
+      AlarmDescription: !Sub '*API Gateway* (${ApiName}) で *分間リクエスト数がプロビジョニングされたスループット値に近づいています* 。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html|Amazon API Gateway のディメンションとメトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-ApiGateway-${ApiName}-Count

--- a/monitoring/sam-app/application-elb.yaml
+++ b/monitoring/sam-app/application-elb.yaml
@@ -53,7 +53,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Application Load Balancer* (${CustomAlarmName}) で *異常なホストが検出* されました。'
+      AlarmDescription: !Sub '*Application Load Balancer* (${CustomAlarmName}) で *異常なホストが検出* されました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html|Application Load Balancer の CloudWatch メトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-ALB-UnHealthyHost
@@ -86,7 +86,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Application Load Balancer* (${CustomAlarmName}) で *5XXレスポンスが発生* しました。'
+      AlarmDescription: !Sub '*Application Load Balancer* (${CustomAlarmName}) で *5XXレスポンスが発生* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html|Application Load Balancer の CloudWatch メトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-ALB-HTTPCode-Target-5XX-Count

--- a/monitoring/sam-app/appstream.yaml
+++ b/monitoring/sam-app/appstream.yaml
@@ -41,7 +41,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Workspaces* (${Fleet}) で容量不足により拒否されたセッションリクエストがあります。'
+      AlarmDescription: !Sub '*Workspaces* (${Fleet}) で *異常なステータスを返した Workspaces* があります。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/workspaces/latest/adminguide/cloudwatch-metrics.html|CloudWatch メトリクス を使用して WorkSpaces をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Workspaces-Unhealthy-${Fleet}

--- a/monitoring/sam-app/config.yaml
+++ b/monitoring/sam-app/config.yaml
@@ -1,23 +1,12 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: CloudWatch alarm for AWS Elemental MediaLive
+Description: CloudWatch alarm for AWS Config
 
 Parameters:
   CustomAlarmName:
     Type: String
     Default: ''
-    Description: The custom alram name
-  InputDeviceId:
-    Type: String
-    Default: ''
-    Description: Input device Id
-  DeviceType:
-    Type: String
-    Default: HD
-    AllowedValues:
-      - HD
-      - UHD
-    Description: The device type 
+    Description: The custom Alram name
   SNSTopicArn:
     Type: String
     AllowedPattern: .+
@@ -42,57 +31,22 @@ Conditions:
   CreateCustomAlarmName: !Not [ !Equals [ !Ref CustomAlarmName, '' ] ]
 
 Resources:
-  Temperature:
+  ChangeNotificationsDeliveryFailed:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*ElementalLink* (${InputDeviceId}) の *筐体温度が上昇* しています。熱暴走を避けるために空冷等の対策を行なってください。'
+      AlarmDescription: !Sub '*Config* で *変更通知の配信に失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/config/latest/developerguide/viewing-the-aws-config-dashboard.html|Viewing the AWS Config Dashboard> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
-        - !Sub Warning-${CustomAlarmName}-ElementalLink-${InputDeviceId}-Temperature-Over-40
-        - !Sub Warning-ElementalLink-${InputDeviceId}-Temperature-Over-40
-      ComparisonOperator: LessThanThreshold
-      Dimensions:
-        - Name: InputDeviceId
-          Value: !Ref InputDeviceId
-        - Name: DeviceType
-          Value: !Ref DeviceType
-      EvaluationPeriods: 1
-      MetricName: Temperature
-      Namespace: AWS/MediaLive
-      OKActions:
-        - !Ref SNSTopicArn
-      Period: 60
-      Statistic: Average
-      Threshold: 1
-      TreatMissingData: notBreaching
-      Tags: 
-        - Key: environment
-          Value: !Ref Environment
-        - Key: !Ref TagKey
-          Value: !Ref TagValue
-  NotRecoveredPackets:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*ElementalLink* (${InputDeviceId}) が *パケットを受信できていません* 。予備に切り替えるなどの操作を行なってください。'
-      AlarmName: !If
-        - CreateCustomAlarmName
-        - !Sub Warning-${CustomAlarmName}-ElementalLink-${InputDeviceId}-NotRecoveredPackets
-        - !Sub Warning-ElementalLink-${InputDeviceId}-NotRecoveredPackets
+        - !Sub Notice-${CustomAlarmName}-Config-ChangeNotificationsDeliveryFailed
+        - Notice-Config-ChangeNotificationsDeliveryFailed
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: InputDeviceId
-          Value: !Ref InputDeviceId
-        - Name: DeviceType
-          Value: !Ref DeviceType
+      DatapointsToAlarm: 1
       EvaluationPeriods: 1
-      MetricName: NotRecoveredPackets
-      Namespace: AWS/MediaLive
+      MetricName: ChangeNotificationsDeliveryFailed
+      Namespace: AWS/Config
       OKActions:
         - !Ref SNSTopicArn
       Period: 60
@@ -104,26 +58,49 @@ Resources:
           Value: !Ref Environment
         - Key: !Ref TagKey
           Value: !Ref TagValue
-  ErrorSeconds:
+  ConfigHistoryExportFailed:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*ElementalLink* (${InputDeviceId}) で *エラーが発生* しています。予備に切り替えるなどの操作を行なってください。'
+      AlarmDescription: !Sub '*Config* で *設定履歴のエクスポートに失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/config/latest/developerguide/viewing-the-aws-config-dashboard.html|Viewing the AWS Config Dashboard> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
-        - !Sub Warning-${CustomAlarmName}-ElementalLink-${InputDeviceId}-ErrorSeconds
-        - !Sub Warning-ElementalLink-${InputDeviceId}-ErrorSeconds
+        - !Sub Notice-${CustomAlarmName}-Config-ConfigHistoryExportFailed
+        - Notice-Config-ConfigHistoryExportFailed
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Dimensions:
-        - Name: InputDeviceId
-          Value: !Ref InputDeviceId
-        - Name: DeviceType
-          Value: !Ref DeviceType
+      DatapointsToAlarm: 1
       EvaluationPeriods: 1
-      MetricName: ErrorSeconds
-      Namespace: AWS/MediaLive
+      MetricName: ConfigHistoryExportFailed
+      Namespace: AWS/Config
+      OKActions:
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+  ConfigSnapshotExportFailed:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*Config* で *設定スナップショットのエクスポートに失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/config/latest/developerguide/viewing-the-aws-config-dashboard.html|Viewing the AWS Config Dashboard> をご覧ください。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Notice-${CustomAlarmName}-Config-ConfigSnapshotExportFailed
+        - Notice-Config-ConfigSnapshotExportFailed
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: ConfigSnapshotExportFailed
+      Namespace: AWS/Config
       OKActions:
         - !Ref SNSTopicArn
       Period: 60

--- a/monitoring/sam-app/config.yaml
+++ b/monitoring/sam-app/config.yaml
@@ -40,8 +40,8 @@ Resources:
       AlarmDescription: !Sub '*Config* で *変更通知の配信に失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/config/latest/developerguide/viewing-the-aws-config-dashboard.html|Viewing the AWS Config Dashboard> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
-        - !Sub Notice-${CustomAlarmName}-Config-ChangeNotificationsDeliveryFailed
-        - Notice-Config-ChangeNotificationsDeliveryFailed
+        - !Sub Warning-${CustomAlarmName}-Config-ChangeNotificationsDeliveryFailed
+        - Warning-Config-ChangeNotificationsDeliveryFailed
       ComparisonOperator: GreaterThanOrEqualToThreshold
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
@@ -67,8 +67,8 @@ Resources:
       AlarmDescription: !Sub '*Config* で *設定履歴のエクスポートに失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/config/latest/developerguide/viewing-the-aws-config-dashboard.html|Viewing the AWS Config Dashboard> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
-        - !Sub Notice-${CustomAlarmName}-Config-ConfigHistoryExportFailed
-        - Notice-Config-ConfigHistoryExportFailed
+        - !Sub Warning-${CustomAlarmName}-Config-ConfigHistoryExportFailed
+        - Warning-Config-ConfigHistoryExportFailed
       ComparisonOperator: GreaterThanOrEqualToThreshold
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
@@ -94,8 +94,8 @@ Resources:
       AlarmDescription: !Sub '*Config* で *設定スナップショットのエクスポートに失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/config/latest/developerguide/viewing-the-aws-config-dashboard.html|Viewing the AWS Config Dashboard> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
-        - !Sub Notice-${CustomAlarmName}-Config-ConfigSnapshotExportFailed
-        - Notice-Config-ConfigSnapshotExportFailed
+        - !Sub Warning-${CustomAlarmName}-Config-ConfigSnapshotExportFailed
+        - Warning-Config-ConfigSnapshotExportFailed
       ComparisonOperator: GreaterThanOrEqualToThreshold
       DatapointsToAlarm: 1
       EvaluationPeriods: 1

--- a/monitoring/sam-app/directoryservice.yaml
+++ b/monitoring/sam-app/directoryservice.yaml
@@ -75,7 +75,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Directory Service* (${CustomAlarmName}) で再帰的なクエリの失敗が発生しています。'
+      AlarmDescription: !Sub '*Directory Service* (${CustomAlarmName}) で再帰的なクエリの失敗が発生しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/directoryservice/latest/admin-guide/ms_ad_monitor_dc_performance.html|パフォーマンスメトリクスを使用してドメインコントローラーをモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-DirectoryService-RecursiveQueryFailure-{DirectoryId}

--- a/monitoring/sam-app/elasticsearch.yaml
+++ b/monitoring/sam-app/elasticsearch.yaml
@@ -53,7 +53,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *クラスタ異常が発生* しています。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *クラスタ異常が発生* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Elasticsearch-${DomainName}-Cluster-Status
@@ -118,7 +118,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *マスターノードで異常が発生* しています。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *マスターノードで異常が発生* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Elasticsearch-${DomainName}-Master-Reachable-From-Node
@@ -150,7 +150,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *自動スナップショットの作成が失敗* しました。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *自動スナップショットの作成が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-Elasticsearch-${DomainName}-Automated-Snapshot-Failure
@@ -182,7 +182,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *Kibanaの異常が発生* しています。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *Kibanaの異常が発生* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Elasticsearch-${DomainName}-Kibana-Healthy-Nodes
@@ -214,7 +214,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) の *ディスクの空き容量が減少* しています。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) の *ディスクの空き容量が減少* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Elasticsearch-${DomainName}-Free-Storage-Space
@@ -246,7 +246,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *マスターノードのCPU使用率が上昇* しています。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *マスターノードのCPU使用率が上昇* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-Elasticsearch-${DomainName}-Master-CPU-Utilization
@@ -278,7 +278,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *マスターノードのJVMメモリ負荷率が上昇* しています。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *マスターノードのJVMメモリ負荷率が上昇* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-Elasticsearch-${DomainName}-Master-JVM-Memory-Pressure
@@ -310,7 +310,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *データノードのCPU使用率が上昇* しています。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *データノードのCPU使用率が上昇* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-Elasticsearch-${DomainName}-Data-CPU-Utilization
@@ -342,7 +342,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *データノードのJVMメモリ負荷率が上昇* しています。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *データノードのJVMメモリ負荷率が上昇* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-Elasticsearch-${DomainName}-Data-JVM-Memory-Pressure
@@ -374,7 +374,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *データノードのメモリ使用率が上昇* しています。'
+      AlarmDescription: !Sub '*Elasticsearch* (${DomainName}) で *データノードのメモリ使用率が上昇* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html|Amazon CloudWatch による OpenSearch クラスターメトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-Elasticsearch-${DomainName}-Data-Sys-Memory-Utilization

--- a/monitoring/sam-app/events.yaml
+++ b/monitoring/sam-app/events.yaml
@@ -50,7 +50,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions: 
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*${EventsRuleName}* の *呼び出しが失敗* しました。'
+      AlarmDescription: !Sub '*${EventsRuleName}* の *呼び出しが失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/eventbridge/latest/userguide/eb-monitoring.html#eb-metrics|EventBridge メトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-Events-${EventsRuleName}-FailedInvocations

--- a/monitoring/sam-app/firehose.yaml
+++ b/monitoring/sam-app/firehose.yaml
@@ -55,7 +55,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *Elasticsearchへの配信遅延が発生* しています。'
+      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *OpenSearch Service への配信遅延が発生* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/firehose/latest/dev/monitoring-with-cloudwatch-metrics.html|CloudWatch メトリクスによる Amazon Data Firehose のモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Notice-${CustomAlarmName}-Firehose-${FirehoseStreamName}-Delivery-To-Elasticsearch-Data-Freshness
@@ -85,7 +85,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *ThrottledGetShardIteratorが発生* しています。'
+      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *ThrottledGetShardIteratorが発生* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/firehose/latest/dev/monitoring-with-cloudwatch-metrics.html|CloudWatch メトリクスによる Amazon Data Firehose のモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Firehose-${FirehoseStreamName}-Throttled-Get-Shard-Iterator
@@ -115,7 +115,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *ThrottledGetRecordsが発生* しています。'
+      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *ThrottledGetRecordsが発生* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/firehose/latest/dev/monitoring-with-cloudwatch-metrics.html|CloudWatch メトリクスによる Amazon Data Firehose のモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Firehose-${FirehoseStreamName}-Throttled-Get-Records
@@ -145,7 +145,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *Elasticsearchへのデータ配信が失敗* しています。'
+      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *OpenSearch Service へのデータ配信が失敗* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/firehose/latest/dev/monitoring-with-cloudwatch-metrics.html|CloudWatch メトリクスによる Amazon Data Firehose のモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Firehose-${FirehoseStreamName}-Delivery-To-Elasticsearch-Failed
@@ -175,7 +175,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *S3へのデータ配信が失敗* しています。'
+      AlarmDescription: !Sub '*Firehose* (${FirehoseStreamName}) で *S3へのデータ配信が失敗* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/firehose/latest/dev/monitoring-with-cloudwatch-metrics.html|CloudWatch メトリクスによる Amazon Data Firehose のモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Firehose-${FirehoseStreamName}-Delivery-To-S3-Failed

--- a/monitoring/sam-app/lambda.yaml
+++ b/monitoring/sam-app/lambda.yaml
@@ -3,6 +3,13 @@ Transform: AWS::Serverless-2016-10-31
 Description: CloudWatch alarm for AWS Lambda
 
 Parameters:
+  AlarmLevel:
+    Type: String
+    Default: NOTICE
+    AllowedValues:
+      - NOTICE
+      - WARNING
+    Description: The alarm level of CloudWatch alarms
   CustomAlarmName:
     Type: String
     Default: ''
@@ -43,6 +50,7 @@ Parameters:
 Conditions:
   CreateCustomAlarmName: !Not [ !Equals [ !Ref CustomAlarmName, '' ] ]
   CreateMetricFilter: !Not [ !Equals [ !Ref MetricFilterPattern, '' ] ]
+  CreateNoticeAlarm: !Not [ !Equals [ !Ref AlarmLevel, WARNING ] ]
 
 Resources:
   AlarmLambdaErrors:
@@ -115,6 +123,7 @@ Resources:
         - Key: !Ref TagKey
           Value: !Ref TagValue
   AlarmLambdaTimeoutWillOccur:
+    Condition: CreateNoticeAlarm
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true

--- a/monitoring/sam-app/mediaconnect-source.yaml
+++ b/monitoring/sam-app/mediaconnect-source.yaml
@@ -45,7 +45,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePTSError* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePTSError* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourcePTSError
@@ -74,7 +74,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceCRCError* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceCRCError* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourceCRCError
@@ -103,7 +103,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePIDError* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePIDError* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourcePIDError
@@ -132,7 +132,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceCATError* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceCATError* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourceCATError
@@ -161,7 +161,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceTSByteError* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceTSByteError* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourceTSByteError
@@ -190,7 +190,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePMTError* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePMTError* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourcePMTError
@@ -219,7 +219,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceTSSyncLoss* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceTSSyncLoss* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourceTSSyncLoss
@@ -248,7 +248,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePATError* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePATError* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourcePATError
@@ -277,7 +277,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceTransportError* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceTransportError* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourceTransportError
@@ -306,7 +306,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceDroppedPackets* が発生しました。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourceDroppedPackets* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourceDroppedPackets
@@ -335,7 +335,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePacketLossPercent* が上昇しています。'
+      AlarmDescription: !Sub '*MediaConnect* (${SourceName}) の入力で *SourcePacketLossPercent* が上昇しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconnect/latest/ug/monitor-with-cloudwatch.html|Amazon CloudWatch メトリクスを使用し、AWS Elemental MediaConnect をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaConnect-${SourceName}-SourcePacketLossPercent

--- a/monitoring/sam-app/mediaconvert.yaml
+++ b/monitoring/sam-app/mediaconvert.yaml
@@ -1,0 +1,265 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+Description: CloudWatch alarm for AWS Elemental MediaConvert
+
+Parameters:
+  CustomAlarmName:
+    Type: String
+    Default: ''
+    Description: The custom alram name
+  SNSTopicArn:
+    Type: String
+    AllowedPattern: .+
+    Description: The SNS topic ARN [required]
+  Environment:
+    Type: String
+    Default: production
+    AllowedValues:
+      - production
+      - test
+      - development
+  TagKey:
+    Type: String
+    Default: createdby
+    AllowedPattern: .+
+  TagValue:
+    Type: String
+    Default: aws-cloudformation-templates
+    AllowedPattern: .+
+
+Conditions:
+  CreateCustomAlarmName: !Not [ !Equals [ !Ref CustomAlarmName, '' ] ]
+
+Resources:
+  CreateJobErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions: 
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*MediaConvert* で *CreateJob が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconvert/latest/ug/metrics.html|MediaConvert CloudWatch メトリクスのリスト> をご覧ください。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Warning-${CustomAlarmName}-MediaConvert-CreateJob-Errors
+        - !Sub Warning-MediaConvert-CreateJob-Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: Operation
+          Value: CreateJob
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/MediaConvert
+      OKActions: 
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+  GetJobErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions: 
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*MediaConvert* で *GetJob が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconvert/latest/ug/metrics.html|MediaConvert CloudWatch メトリクスのリスト> をご覧ください。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Warning-${CustomAlarmName}-MediaConvert-GetJob-Errors
+        - !Sub Warning-MediaConvert-GetJob-Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: Operation
+          Value: GetJob
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/MediaConvert
+      OKActions: 
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+  GetQueueErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions: 
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*MediaConvert* で *GetQueue が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconvert/latest/ug/metrics.html|MediaConvert CloudWatch メトリクスのリスト> をご覧ください。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Warning-${CustomAlarmName}-MediaConvert-GetQueue-Errors
+        - !Sub Warning-MediaConvert-GetQueue-Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: Operation
+          Value: GetQueue
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/MediaConvert
+      OKActions: 
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+  ListJobsErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions: 
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*MediaConvert* で *ListJobs が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconvert/latest/ug/metrics.html|MediaConvert CloudWatch メトリクスのリスト> をご覧ください。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Warning-${CustomAlarmName}-MediaConvert-ListJobs-Errors
+        - !Sub Warning-MediaConvert-ListJobs-Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: Operation
+          Value: ListJobs
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/MediaConvert
+      OKActions: 
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+  ListJobTemplatesErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions: 
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*MediaConvert* で *ListJobTemplates が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconvert/latest/ug/metrics.html|MediaConvert CloudWatch メトリクスのリスト> をご覧ください。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Warning-${CustomAlarmName}-MediaConvert-ListJobTemplates-Errors
+        - !Sub Warning-MediaConvert-ListJobTemplates-Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: Operation
+          Value: ListJobTemplates
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/MediaConvert
+      OKActions: 
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+  ListPresetsErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions: 
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*MediaConvert* で *ListPresets が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconvert/latest/ug/metrics.html|MediaConvert CloudWatch メトリクスのリスト> をご覧ください。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Warning-${CustomAlarmName}-MediaConvert-ListPresets-Errors
+        - !Sub Warning-MediaConvert-ListPresets-Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: Operation
+          Value: ListPresets
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/MediaConvert
+      OKActions: 
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+  ListQueuesErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions: 
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*MediaConvert* で *ListQueues が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconvert/latest/ug/metrics.html|MediaConvert CloudWatch メトリクスのリスト> をご覧ください。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Warning-${CustomAlarmName}-MediaConvert-ListQueues-Errors
+        - !Sub Warning-MediaConvert-ListQueues-Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: Operation
+          Value: ListQueues
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/MediaConvert
+      OKActions: 
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+  ListTagsForResourceErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions: 
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*MediaConvert* で *ListTagsForResource が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/mediaconvert/latest/ug/metrics.html|MediaConvert CloudWatch メトリクスのリスト> をご覧ください。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Warning-${CustomAlarmName}-MediaConvert-ListTagsForResource-Errors
+        - !Sub Warning-MediaConvert-ListTagsForResource-Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: Operation
+          Value: ListTagsForResource
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/MediaConvert
+      OKActions: 
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue

--- a/monitoring/sam-app/medialive.yaml
+++ b/monitoring/sam-app/medialive.yaml
@@ -49,7 +49,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaLive* (${ChannelId}) の出力で *4XX エラー* が発生しました。'
+      AlarmDescription: !Sub '*MediaLive* (${ChannelId}) の出力で *4XX エラー* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/medialive/latest/ug/monitoring-eml-metrics.html|Amazon CloudWatch メトリクスを使用したチャネルのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaLive-${ChannelId}-4XX-Error-Occured
@@ -82,7 +82,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaLive* (${ChannelId}) の出力で *5XX エラー* が発生しました。'
+      AlarmDescription: !Sub '*MediaLive* (${ChannelId}) の出力で *5XX エラー* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/medialive/latest/ug/monitoring-eml-metrics.html|Amazon CloudWatch メトリクスを使用したチャネルのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaLive-${ChannelId}-5XX-Error-Occured
@@ -115,7 +115,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaLive* (${ChannelId}) で *アラートが発生* しています。'
+      AlarmDescription: !Sub '*MediaLive* (${ChannelId}) で *アラートが発生* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/medialive/latest/ug/monitoring-eml-metrics.html|Amazon CloudWatch メトリクスを使用したチャネルのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaLive-${ChannelId}-Active-Alerts
@@ -146,7 +146,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaLive* (${ChannelId}) の *現用入力が非アクティブ* です。'
+      AlarmDescription: !Sub '*MediaLive* (${ChannelId}) の *現用入力が非アクティブ* です。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/medialive/latest/ug/monitoring-eml-metrics.html|Amazon CloudWatch メトリクスを使用したチャネルのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaLive-${ChannelId}-Primary-Input-Inactive

--- a/monitoring/sam-app/mediastore.yaml
+++ b/monitoring/sam-app/mediastore.yaml
@@ -41,7 +41,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaStore* (${ContainerName}) の *PutRequestsでスロットリングが発生* しました。'
+      AlarmDescription: !Sub '*MediaStore* (${ContainerName}) の *PutRequestsでスロットリングが発生* しました。このエラーの詳細は、<https://docs.aws.amazon.com/mediastore/latest/ug/monitor-with-cloudwatch-metrics.html|Monitoring AWS Elemental MediaStore with Amazon CloudWatch metrics
+> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaStore-${ContainerName}-PutRequests-Throttle
@@ -72,7 +73,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaStore* (${ContainerName}) の *ListRequestsでスロットリングが発生* しました。'
+      AlarmDescription: !Sub '*MediaStore* (${ContainerName}) の *ListRequestsでスロットリングが発生* しました。このエラーの詳細は、<https://docs.aws.amazon.com/mediastore/latest/ug/monitor-with-cloudwatch-metrics.html|Monitoring AWS Elemental MediaStore with Amazon CloudWatch metrics
+> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaStore-${ContainerName}-ListRequests-Throttle
@@ -103,7 +105,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*MediaStore* (${ContainerName}) の *DeleteRequestsスロットリングが発生* しました。'
+      AlarmDescription: !Sub '*MediaStore* (${ContainerName}) の *DeleteRequestsスロットリングが発生* しました。このエラーの詳細は、<https://docs.aws.amazon.com/mediastore/latest/ug/monitor-with-cloudwatch-metrics.html|Monitoring AWS Elemental MediaStore with Amazon CloudWatch metrics
+> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-MediaStore-${ContainerName}-DeleteRequests-Throttle

--- a/monitoring/sam-app/network-elb.yaml
+++ b/monitoring/sam-app/network-elb.yaml
@@ -1,15 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: CloudWatch alarm for Application Load Balancer
+Description: CloudWatch alarm for Network Load Balancer
 
 Parameters:
-  AlarmLevel:
-    Type: String
-    Default: NOTICE
-    AllowedValues:
-      - NOTICE
-      - WARNING
-    Description: The alarm level of CloudWatch alarms
   CustomAlarmName:
     Type: String
     Default: ''
@@ -18,14 +11,14 @@ Parameters:
     Type: String
     AllowedPattern: .+
     Description: The load balancer name [required]  
-  SNSTopicArn:
-    Type: String
-    AllowedPattern: .+
-    Description: The SNS topic ARN [required]
   TargetGroup:
     Type: String
     AllowedPattern: .+
     Description: The target group id [required]
+  SNSTopicArn:
+    Type: String
+    AllowedPattern: .+
+    Description: The SNS topic ARN [required]
   Environment:
     Type: String
     Default: production
@@ -44,30 +37,29 @@ Parameters:
 
 Conditions:
   CreateCustomAlarmName: !Not [ !Equals [ !Ref CustomAlarmName, '' ] ]
-  CreateNoticeAlarm: !Not [ !Equals [ !Ref AlarmLevel, WARNING ] ]
 
 Resources:
-  UnHealthyHost:
+  UnHealthyHostCount:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Application Load Balancer* (${CustomAlarmName}) で *異常なホストが検出* されました。'
+      AlarmDescription: !Sub '*Network Load Balancer* (${CustomAlarmName}) で *異常なホストが検出* されました。'
       AlarmName: !If
         - CreateCustomAlarmName
-        - !Sub Warning-${CustomAlarmName}-ALB-UnHealthyHost
-        - Warning-ALB-UnHealthyHost
+        - !Sub Warning-${CustomAlarmName}-NLB-UnHealthyHostCount
+        - Warning-NLB-UnHealthyHostCount
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-        - Name: TargetGroup
-          Value: !Ref TargetGroup
         - Name: LoadBalancer
           Value: !Ref LoadBalancer
+        - Name: TargetGroup
+          Value: !Ref TargetGroup
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
       MetricName: UnHealthyHostCount
-      Namespace: AWS/ApplicationELB
+      Namespace: AWS/NetworkELB
       OKActions:
         - !Ref SNSTopicArn
       Period: 60
@@ -79,28 +71,25 @@ Resources:
           Value: !Ref Environment
         - Key: !Ref TagKey
           Value: !Ref TagValue
-  HTTPCodeTarget5XX:
-    Condition: CreateNoticeAlarm
+  PortAllocationErrorCount:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Application Load Balancer* (${CustomAlarmName}) で *5XXレスポンスが発生* しました。'
+      AlarmDescription: !Sub '*Network Load Balancer* (${CustomAlarmName}) で *ポート割り当てエラー* が発生しました。'
       AlarmName: !If
         - CreateCustomAlarmName
-        - !Sub Notice-${CustomAlarmName}-ALB-HTTPCode-Target-5XX-Count
-        - Notice-ALB-HTTPCode-Target-5XX-Count
-      ComparisonOperator: LessThanOrEqualToThreshold
+        - !Sub Warning-${CustomAlarmName}-NLB-PortAllocationErrorCount
+        - Warning-NLB-PortAllocationErrorCount
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-        - Name: TargetGroup
-          Value: !Ref TargetGroup
         - Name: LoadBalancer
           Value: !Ref LoadBalancer
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
-      MetricName: HTTPCode_Target_5XX_Count
-      Namespace: AWS/ApplicationELB
+      MetricName: PortAllocationErrorCount
+      Namespace: AWS/NetworkELB
       OKActions:
         - !Ref SNSTopicArn
       Period: 60

--- a/monitoring/sam-app/network-elb.yaml
+++ b/monitoring/sam-app/network-elb.yaml
@@ -45,7 +45,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Network Load Balancer* (${CustomAlarmName}) で *異常なホストが検出* されました。'
+      AlarmDescription: !Sub '*Network Load Balancer* (${CustomAlarmName}) で *異常なホストが検出* されました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/elasticloadbalancing/latest/network/load-balancer-cloudwatch-metrics.html|Network Load Balancer の CloudWatch メトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-NLB-UnHealthyHostCount
@@ -77,7 +77,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Network Load Balancer* (${CustomAlarmName}) で *ポート割り当てエラー* が発生しました。'
+      AlarmDescription: !Sub '*Network Load Balancer* (${CustomAlarmName}) で *ポート割り当てエラー* が発生しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/elasticloadbalancing/latest/network/load-balancer-cloudwatch-metrics.html|Network Load Balancer の CloudWatch メトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-NLB-PortAllocationErrorCount

--- a/monitoring/sam-app/privateendpoints.yaml
+++ b/monitoring/sam-app/privateendpoints.yaml
@@ -53,7 +53,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*PrivateLinkEndpoints* (${VPCEndpointId}) で *パケットのドロップ* が発生しています。'
+      AlarmDescription: !Sub '*PrivateLinkEndpoints* (${VPCEndpointId}) で *パケットのドロップ* が発生しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/vpc/latest/privatelink/privatelink-cloudwatch-metrics.html|AWS PrivateLink の CloudWatch メトリクス> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-PrivateLinkEndpoints-PacketsDropped-Occured-${VPCEndpointId}

--- a/monitoring/sam-app/route53-resolver.yaml
+++ b/monitoring/sam-app/route53-resolver.yaml
@@ -1,20 +1,20 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: CloudWatch alarm for Amazon AppFlow
+Description: CloudWatch alarm for Amazon Route 53 Resolver
 
 Parameters:
   CustomAlarmName:
     Type: String
     Default: ''
     Description: The custom Alram name
+  EndpointId:
+    Type: String
+    AllowedPattern: .+
+    Description: The endpoint ID of the Route 53 Resolver [required]  
   SNSTopicArn:
     Type: String
     AllowedPattern: .+
     Description: The SNS topic ARN [required]
-  FlowName:
-    Type: String
-    AllowedPattern: .+
-    Description: The AppFlow flow name [required]
   Environment:
     Type: String
     Default: production
@@ -29,35 +29,35 @@ Parameters:
   TagValue:
     Type: String
     Default: aws-cloudformation-templates
-    AllowedPattern: .+    
+    AllowedPattern: .+
 
 Conditions:
   CreateCustomAlarmName: !Not [ !Equals [ !Ref CustomAlarmName, '' ] ]
 
 Resources:
-  AppFlowExecutionsFailed:
+  EndpointUnhealthyENICount:
     Type: AWS::CloudWatch::Alarm
     Properties:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*AppFlow* (${FlowName}) でフローの実行が失敗しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/appflow/latest/userguide/monitoring-cloudwatch.html|Monitoring Amazon AppFlow with Amazon CloudWatch> をご覧ください。'
+      AlarmDescription: '*Route53 Resolver* に *復旧の必要のある ENI* があります。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/Route53/latest/DeveloperGuide/monitoring-resolver-with-cloudwatch.html|Amazon CloudWatch による Route 53 Resolver エンドポイントのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
-        - !Sub Warning-${CustomAlarmName}-AppFlow-FlowExecutionsFailed
-        - Warning-AppFlow-FlowExecutionsFailed
-      ComparisonOperator: LessThanOrEqualToThreshold
+        - !Sub Notice-${CustomAlarmName}-Route53Resolver-EndpointUnhealthyENICount
+        - Notice-Route53Resolver-EndpointUnhealthyENICount
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
-        - Name: FlowName
-          Value: !Ref FlowName
+        - Name: EndpointId
+          Value: !Ref EndpointId
       DatapointsToAlarm: 1
       EvaluationPeriods: 1
-      MetricName: FlowExecutionsFailed
-      Namespace: AWS/AppFlow
+      MetricName: EndpointUnhealthyENICount
+      Namespace: AWS/Route53Resolver
       OKActions:
         - !Ref SNSTopicArn
       Period: 60
-      Statistic: Sum
+      Statistic: Maximum
       Threshold: 1
       TreatMissingData: notBreaching
       Tags: 

--- a/monitoring/sam-app/ssm-command.yaml
+++ b/monitoring/sam-app/ssm-command.yaml
@@ -37,7 +37,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*SSM (RunCommand)* で *タイムアウト* が発生しています。'
+      AlarmDescription: !Sub '*SSM (RunCommand)* で *タイムアウト* が発生しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/systems-manager/latest/userguide/monitoring-cloudwatch-metrics.html|Amazon CloudWatch を使用した Run Command メトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-SSM-DeliveryTimedOut
@@ -64,7 +64,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*SSM (RunCommand)* で *コマンド実行が失敗* しました。'
+      AlarmDescription: !Sub '*SSM (RunCommand)* で *コマンド実行が失敗* しました。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/systems-manager/latest/userguide/monitoring-cloudwatch-metrics.html|Amazon CloudWatch を使用した Run Command メトリクスのモニタリング> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-SSM-CommandsFailed

--- a/monitoring/sam-app/vpn.yaml
+++ b/monitoring/sam-app/vpn.yaml
@@ -1,0 +1,67 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+Description: CloudWatch alarm for Site-to-Site VPN
+
+Parameters:
+  CustomAlarmName:
+    Type: String
+    Default: ''
+    Description: The custom Alram name
+  SNSTopicArn:
+    Type: String
+    AllowedPattern: .+
+    Description: The SNS topic ARN [required]
+  VpnId:
+    Type: String
+    AllowedPattern: .+
+    Description: The id of the VPN ID [required]
+  Environment:
+    Type: String
+    Default: production
+    AllowedValues:
+      - production
+      - test
+      - development
+  TagKey:
+    Type: String
+    Default: createdby
+    AllowedPattern: .+
+  TagValue:
+    Type: String
+    Default: aws-cloudformation-templates
+    AllowedPattern: .+  
+
+Conditions:
+  CreateCustomAlarmName: !Not [ !Equals [ !Ref CustomAlarmName, '' ] ]
+
+Resources:
+  Down:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref SNSTopicArn
+      AlarmDescription: !Sub '*VPN* (${VpnId}) が DOWN しています。'
+      AlarmName: !If
+        - CreateCustomAlarmName
+        - !Sub Warning-${CustomAlarmName}-VPN-Down-${VpnId}
+        - !Sub Warning-VPN-Down-${VpnId}
+      ComparisonOperator: LessThanThreshold
+      Dimensions:
+        - Name: VpnId
+          Value: !Ref VpnId
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: TunnelState
+      Namespace: AWS/VPN
+      OKActions:
+        - !Ref SNSTopicArn
+      Period: 60
+      Statistic: Minimum
+      Threshold: 1
+      TreatMissingData: notBreaching
+      Tags: 
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue

--- a/monitoring/sam-app/vpn.yaml
+++ b/monitoring/sam-app/vpn.yaml
@@ -41,7 +41,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*VPN* (${VpnId}) が DOWN しています。'
+      AlarmDescription: !Sub '*VPN* (${VpnId}) が *DOWN* しています。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/vpn/latest/s2svpn/monitoring-cloudwatch-vpn.html|Amazon CloudWatch を使用して AWS Site-to-Site VPN トンネルをモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-VPN-Down-${VpnId}

--- a/monitoring/sam-app/workspaces.yaml
+++ b/monitoring/sam-app/workspaces.yaml
@@ -41,7 +41,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref SNSTopicArn
-      AlarmDescription: !Sub '*Workspaces* (${DirectoryId}) に正常ではない端末があります。'
+      AlarmDescription: !Sub '*Workspaces* (${DirectoryId}) に正常ではない端末があります。このエラーの詳細は、<https://docs.aws.amazon.com/ja_jp/workspaces/latest/adminguide/cloudwatch-metrics.html|CloudWatch メトリクスを使用して WorkSpaces をモニタリングする> をご覧ください。'
       AlarmName: !If
         - CreateCustomAlarmName
         - !Sub Warning-${CustomAlarmName}-Workspaces-Unhealthy-${DirectoryId}

--- a/network/templates/az.yaml
+++ b/network/templates/az.yaml
@@ -84,9 +84,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   LogicalName:
     Type: String
     Default: WebServers
@@ -311,7 +313,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-natgateway
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !Ref SNSForDeploymentArn
       Parameters:

--- a/network/templates/egress.yaml
+++ b/network/templates/egress.yaml
@@ -131,9 +131,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   LogicalName: 
     Type: String
     Default: Egress
@@ -174,7 +176,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -214,7 +216,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -254,7 +256,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -425,7 +427,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -442,7 +444,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${LogicalName}
       Tags:
@@ -600,7 +602,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-transitgateway-attachment
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/network/templates/route53resolver.yaml
+++ b/network/templates/route53resolver.yaml
@@ -575,6 +575,43 @@ Resources:
       VPCs: 
         - VPCId: !Ref VPC
           VPCRegion: !Ref AWS::Region
+  # CloudWatch
+  CloudWatchAlarmRoute53ResolverInbound:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-route53-resolver
+        SemanticVersion: 2.2.9
+      NotificationARNs: 
+        - !Ref SNSForDeploymentArn
+      Parameters:
+        CustomAlarmName: !Ref AWS::StackName
+        EndpointId: !Ref Route53ResolverInbound
+        SNSTopicArn: !Ref SNSForAlertArn
+        Environment: !Ref Environment
+        TagKey: !Ref TagKey
+        TagValue: !Ref TagValue
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
+  CloudWatchAlarmRoute53ResolverOutbound:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-route53-resolver
+        SemanticVersion: 2.2.9
+      NotificationARNs: 
+        - !Ref SNSForDeploymentArn
+      Parameters:
+        CustomAlarmName: !Ref AWS::StackName
+        EndpointId: !Ref Route53ResolverOutbound
+        SNSTopicArn: !Ref SNSForAlertArn
+        Environment: !Ref Environment
+        TagKey: !Ref TagKey
+        TagValue: !Ref TagValue
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
 
 Outputs:
   ResolverOutboundRuleId:

--- a/network/templates/route53resolver.yaml
+++ b/network/templates/route53resolver.yaml
@@ -109,10 +109,12 @@ Parameters:
     Description: The VPC CIDR block [required]
   SNSForAlertArn:
     Type: String
-    Default: '' 
+    Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   LogicalName: 
     Type: String
     Default: Route53Resolver
@@ -147,7 +149,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -181,7 +183,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -215,7 +217,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -250,7 +252,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -267,7 +269,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${LogicalName}
       Tags:

--- a/network/templates/template.yaml
+++ b/network/templates/template.yaml
@@ -210,9 +210,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -373,6 +375,14 @@ Resources:
       Parameters:
         CustomerGatewayOutsideIpAddress: !Ref CustomerGatewayOutsideIpAddress
         TransitGatewayId: !GetAtt TransitGateway.Outputs.TransitGatewayId
+        SNSForAlertArn: !If
+          - CreateSNSForAlert
+          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
+          - !Ref SNSForAlertArn
+        SNSForDeploymentArn: !If
+          - CreateSNSForDeployment
+          - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
+          - !Ref SNSForDeploymentArn 
         Environment: !Ref Environment
         LogicalName: !Ref AWS::StackName
         TagKey: !Ref TagKey
@@ -439,7 +449,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -456,7 +466,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/network/templates/transitgateway.yaml
+++ b/network/templates/transitgateway.yaml
@@ -41,10 +41,12 @@ Parameters:
     Description: The custom prefix name [required]
   SNSForAlertArn:
     Type: String
-    Default: '' 
+    Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   TagKey:
     Type: String
     Default: createdby
@@ -67,7 +69,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -84,7 +86,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -144,7 +146,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-transitgateway
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/network/templates/vpn.yaml
+++ b/network/templates/vpn.yaml
@@ -12,6 +12,11 @@ Metadata:
           - StaticRoutesOnly
           - TransitGatewayId
       - Label: 
+          default: 'Notofication Configuration'
+        Parameters:
+          - SNSForAlertArn 
+          - SNSForDeploymentArn
+      - Label: 
           default: 'Tag Configuration'
         Parameters:
           - Environment 
@@ -35,6 +40,14 @@ Parameters:
     Type: String
     AllowedPattern: .+
     Description: The ID of the transit gateway associated with the VPN connection [required] 
+  SNSForAlertArn:
+    Type: String
+    AllowedPattern: .+
+    Description: The Amazon SNS topic ARN for alert [required]
+  SNSForDeploymentArn:
+    Type: String
+    Default: '' 
+    Description: The Amazon SNS topic ARN for deployment information [required]
   Environment:
     Type: String
     Default: production
@@ -84,3 +97,21 @@ Resources:
           Value: !Ref TagValue
       TransitGatewayId: !Ref TransitGatewayId
       Type: ipsec.1
+  CloudWatchAlarmVPN:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-vpn
+        SemanticVersion: 2.2.9
+      NotificationARNs: 
+        - !Ref SNSForDeploymentArn
+      Parameters:
+        CustomAlarmName: !Ref AWS::StackName
+        VpnId: !Ref VPNConnection
+        SNSTopicArn: !Ref SNSForAlertArn
+        Environment: !Ref Environment
+        TagKey: !Ref TagKey
+        TagValue: !Ref TagValue
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue

--- a/notification/README_JP.md
+++ b/notification/README_JP.md
@@ -151,5 +151,5 @@ aws cloudformation deploy --template-file packaged.yaml --stack-name Notificatio
 | TrustedAdvisorEventsRule | ENABLED / DISABLED | ENABLED | ○ | ENABLEDを指定した場合、Trusted Advisor に関するイベントルールを作成します。 |
 | UnauthorizedApiCallsCloudWatchAlarmName | String | | ○ | 認証されていない API コールを通知する CloudWatch アラーム名 |
 | SNSForAlertArn | String | | | アラート用 Amazon SNS トピックの ARN | 
-| SNSForAlertArn | String | | | CI/CD用 Amazon SNS トピックの ARN | 
+| SNSForCICDArn | String | | | CI/CD用 Amazon SNS トピックの ARN | 
 | SNSForDeploymentArn | String | | | デプロイ用 Amazon SNS トピックの ARN |

--- a/notification/sam-app/events.yaml
+++ b/notification/sam-app/events.yaml
@@ -149,11 +149,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: ''
-    Description: Amazon SNS Topic ARN for alert
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
-    Description: Amazon SNS Topic ARN for deployment
+    Description: The Amazon SNS topic ARN for deployment information
 
 Conditions:
   SubscribeAutoScalingErrorEventOnly: !Equals [ !Ref AutoScalingEventsRule, ERROR_ONLY]

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -142,15 +142,15 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: ''
-    Description: Amazon SNS Topic ARN for alert
+    Description: The Amazon SNS topic ARN for alert
   SNSForCICDArn:
     Type: String
     Default: ''
-    Description: Amazon SNS Topic ARN for CICD information
+    Description: The Amazon SNS topic ARN for CI/CD information
   SNSForDeploymentArn:
     Type: String
     Default: '' 
-    Description: Amazon SNS Topic ARN for deployment information
+    Description: The Amazon SNS topic ARN for deployment information
   TagEventsRule:
     Type: String
     Default: ENABLED
@@ -205,7 +205,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -221,7 +221,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -238,7 +238,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -255,7 +255,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -266,7 +266,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/eventbridge-rules
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -525,7 +525,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -606,7 +606,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -698,7 +698,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/notification/sam-app/template.yaml
+++ b/notification/sam-app/template.yaml
@@ -39,6 +39,7 @@ Metadata:
       - Label: 
           default: 'Notification Configuration'
         Parameters: 
+          - AlarmLevel
           - SNSForAlertArn
           - SNSForCICDArn
           - SNSForDeploymentArn
@@ -50,6 +51,13 @@ Metadata:
           - TagValue
 
 Parameters:
+  AlarmLevel:
+    Type: String
+    Default: NOTICE
+    AllowedValues:
+      - NOTICE
+      - WARNING
+    Description: The alarm level of CloudWatch alarms
   AutoScalingEventsRule:
     Type: String
     Default: ENABLED
@@ -524,6 +532,7 @@ Resources:
           - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
           - !Ref SNSForDeploymentArn
       Parameters:
+        AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref AWS::StackName
         SNSTopicArn: !If
           - CreateSNSForAlert
@@ -604,6 +613,7 @@ Resources:
           - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
           - !Ref SNSForDeploymentArn
       Parameters:
+        AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref AWS::StackName
         SNSTopicArn: !If
           - CreateSNSForAlert
@@ -695,6 +705,7 @@ Resources:
           - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
           - !Ref SNSForDeploymentArn
       Parameters:
+        AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref AWS::StackName
         SNSTopicArn: !If
           - CreateSNSForAlert

--- a/security-config-rules/sam-app/template.yaml
+++ b/security-config-rules/sam-app/template.yaml
@@ -58,7 +58,7 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: ''
-    Description: Amazon SNS Topic ARN for alert
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: '' 
@@ -94,7 +94,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -111,7 +111,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -276,7 +276,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/security/templates/config.yaml
+++ b/security/templates/config.yaml
@@ -537,6 +537,7 @@ Resources:
           - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
           - !Ref SNSForDeploymentArn
       Parameters:
+        AlarmLevel: !Ref AlarmLevel
         CustomAlarmName: !Ref AWS::StackName
         SNSTopicArn: !If
           - CreateSNSForDeployment

--- a/security/templates/config.yaml
+++ b/security/templates/config.yaml
@@ -80,7 +80,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -97,7 +97,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${LogicalName}
       Tags:
@@ -421,7 +421,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -530,7 +530,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-lambda
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -901,7 +901,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/security/templates/config.yaml
+++ b/security/templates/config.yaml
@@ -921,3 +921,21 @@ Resources:
       Tags:
         environment: !Ref Environment
         createdby: !Ref TagValue
+  # CloudWatch
+  CloudWatchAlarmConfig:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-config
+        SemanticVersion: 2.2.9
+      NotificationARNs: 
+        - !Ref SNSForDeploymentArn
+      Parameters:
+        CustomAlarmName: !Ref AWS::StackName
+        SNSTopicArn: !Ref SNSForAlertArn
+        Environment: !Ref Environment
+        TagKey: !Ref TagKey
+        TagValue: !Ref TagValue
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue

--- a/security/templates/guardduty.yaml
+++ b/security/templates/guardduty.yaml
@@ -79,7 +79,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -96,7 +96,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${LogicalName}
       Tags:
@@ -159,7 +159,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/security/templates/iam.yaml
+++ b/security/templates/iam.yaml
@@ -80,7 +80,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -97,7 +97,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${LogicalName}
       Tags:
@@ -149,7 +149,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/security/templates/macie.yaml
+++ b/security/templates/macie.yaml
@@ -89,7 +89,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -106,7 +106,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${LogicalName}
       Tags:
@@ -236,7 +236,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/security/templates/securityhub.yaml
+++ b/security/templates/securityhub.yaml
@@ -134,7 +134,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -151,7 +151,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${LogicalName}
       Tags:
@@ -263,7 +263,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment

--- a/security/templates/template.yaml
+++ b/security/templates/template.yaml
@@ -229,9 +229,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -517,7 +519,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -534,7 +536,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -629,7 +631,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -675,7 +677,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-events
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -698,13 +700,13 @@ Resources:
         
 Outputs:
   SNSForAlertArn:
-    Description: SNS ARN for Alert
+    Description: The Amazon SNS topic ARN for alert
     Value: !If
       - CreateSNSForAlert
       - !GetAtt SNSForAlert.Outputs.SNSTopicArn
       - !Ref SNSForAlertArn
   SNSForDeploymentArn:
-    Description: SNS ARN for Deployment
+    Description: The Amazon SNS topic ARN for deployment information
     Value: !If
       - CreateSNSForDeployment
       - !GetAtt SNSForDeployment.Outputs.SNSTopicArn

--- a/shared/templates/fluentbit.yaml
+++ b/shared/templates/fluentbit.yaml
@@ -672,6 +672,25 @@ Resources:
       Tags:
         environment: !Ref Environment
         createdby: !Ref TagValue
+  CloudWatchAlarmNLB:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-network-elb
+        SemanticVersion: 2.2.9
+      NotificationARNs: 
+        - !Ref SNSForDeploymentArn
+      Parameters:
+        CustomAlarmName: !Ref AWS::StackName
+        LoadBalancer: !Ref LoadBalancer
+        TargetGroup: !Ref LoadBalancerTargetGroup
+        SNSTopicArn: !Ref SNSForAlertArn
+        Environment: !Ref Environment
+        TagKey: !Ref TagKey
+        TagValue: !Ref TagValue
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
   CloudWatchLogsGroup:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/shared/templates/fluentbit.yaml
+++ b/shared/templates/fluentbit.yaml
@@ -131,7 +131,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -151,7 +151,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -652,7 +652,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ecs
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/shared/templates/template.yaml
+++ b/shared/templates/template.yaml
@@ -185,6 +185,7 @@ Parameters:
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -248,7 +249,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -282,7 +283,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -316,7 +317,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -413,7 +414,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -430,7 +431,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -771,7 +772,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-transitgateway-attachment
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -796,7 +797,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-privateendpoints
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -823,7 +824,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-privateendpoints
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -850,7 +851,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-privateendpoints
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -877,7 +878,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-privateendpoints
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -904,7 +905,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-privateendpoints
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/static-website-hosting/templates/template.yaml
+++ b/static-website-hosting/templates/template.yaml
@@ -290,9 +290,11 @@ Parameters:
   SNSForAlertArn:
     Type: String
     Default: '' 
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -479,7 +481,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -496,7 +498,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/web-servers/sam-app/ecs-targetgroup.yaml
+++ b/web-servers/sam-app/ecs-targetgroup.yaml
@@ -120,7 +120,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-application-elb
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !Ref SNSForDeploymentArn
       Parameters:

--- a/web-servers/sam-app/ecs.yaml
+++ b/web-servers/sam-app/ecs.yaml
@@ -194,7 +194,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -214,7 +214,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -656,7 +656,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ecs
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !Ref SNSForDeploymentArn
       Parameters:

--- a/web-servers/templates/autoscaling.yaml
+++ b/web-servers/templates/autoscaling.yaml
@@ -171,10 +171,12 @@ Parameters:
     Description: The subnet id 3 for Elastic Load Balancer
   SNSForAlertArn:
     Type: String
-    Default: ''   
+    Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   VPCId:
     Type: AWS::EC2::VPC::Id
     AllowedPattern: .+
@@ -217,7 +219,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -234,7 +236,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -488,7 +490,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-application-elb
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment

--- a/web-servers/templates/codepipeline-container.yaml
+++ b/web-servers/templates/codepipeline-container.yaml
@@ -232,7 +232,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -252,7 +252,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:

--- a/web-servers/templates/template.yaml
+++ b/web-servers/templates/template.yaml
@@ -363,10 +363,12 @@ Parameters:
     Description: Web ACL ARN for CloudFront
   SNSForAlertArn:
     Type: String
-    Default: ''   
+    Default: ''
+    Description: The Amazon SNS topic ARN for alert
   SNSForDeploymentArn:
     Type: String
     Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
   Environment:
     Type: String
     Default: production
@@ -413,7 +415,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -462,7 +464,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -511,7 +513,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/availability-zone
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -821,7 +823,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs:
         - !If
           - CreateSNSForDeployment
@@ -838,7 +840,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       Parameters:
         TopicName: !Sub Deployment-createdby-${AWS::StackName}
       Tags:
@@ -1345,7 +1347,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -1370,7 +1372,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-ec2-cwagent
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -1399,7 +1401,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/cloudwatch-alarm-about-transitgateway-attachment
-        SemanticVersion: 2.2.8
+        SemanticVersion: 2.2.9
       NotificationARNs: 
         - !If
           - CreateSNSForDeployment
@@ -1610,13 +1612,13 @@ Outputs:
       - !GetAtt Az3.Outputs.TransitSubnetId
       - ''
   SNSForAlertArn:
-    Description: SNS ARN for Alert
+    Description: The Amazon SNS topic ARN for alert
     Value: !If
       - CreateSNSForAlert
       - !GetAtt SNSForAlert.Outputs.SNSTopicArn
       - !Ref SNSForAlertArn
   SNSForDeploymentArn:
-    Description: SNS ARN for Deployment
+    Description: The Amazon SNS topic ARN for deployment information
     Value: !If
       - CreateSNSForDeployment
       - !GetAtt SNSForDeployment.Outputs.SNSTopicArn


### PR DESCRIPTION
Description of changes:

+ CloudWatch alarms for Amplify
+ CloudWatch alarms for Config
+ CloudWatch alarms for MediaConvert
+ CloudWatch alarms for Network Load Balancer
+ CloudWatch alarms for Route 53 Resolver
+ CloudWatch alarms for VPN

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.