### PR TITLE
feat(devops): add AWS frontier AI agent support — AWS DevOps Agent

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -1,0 +1,58 @@
+[**日本語**](README_JP.md) / English
+
+# AWSCloudFormationTemplates/devops
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiZ3Z5MUkzdXRFcEtqM25ST0lZdW93ZVBKTnRXTk1WRGFUNkk2MzFpVERGNHp1dHU2RDNReU5IUlAvTitlRGgxNE03N3Y4ejZFaTNDVmpXdDZDK1pjRUFBPSIsIml2UGFyYW1ldGVyU3BlYyI6IllkWXQ5VVNaWE9QSnZkN3EiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
+![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
+
+`AWSCloudFormationTemplates/devops` sets up **AWS frontier AI agents** for DevOps operations. This includes `AWS DevOps Agent` and related resources for autonomous incident response, root cause analysis, and operational excellence.
+
+## TL;DR
+
+If you want to deploy each service individually, click the button below.
+
+| Services | US East (Virginia) | Asia Pacific (Tokyo) |
+| --- | --- | --- |
+| AWS DevOps Agent | [![cloudformation-launch-stack](https://raw.githubusercontent.com/eijikominami/aws-cloudformation-templates/master/images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?stackName=DevOpsAgent&templateURL=https://eijikominami.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/devops/templates/devops-agent.yaml) | [![cloudformation-launch-stack](https://raw.githubusercontent.com/eijikominami/aws-cloudformation-templates/master/images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?stackName=DevOpsAgent&templateURL=https://eijikominami.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/devops/templates/devops-agent.yaml) |
+
+## Architecture
+
+### AWS DevOps Agent
+
+`AWS DevOps Agent` is an always-available **frontier AI agent** that autonomously resolves and proactively prevents incidents, optimizes application reliability, and handles on-demand SRE tasks across AWS, multicloud, and on-premises environments.
+
+This template provisions all prerequisites for AWS DevOps Agent:
+
+- **IAM roles** — service role (`aidevops.amazonaws.com`) with `AIDevOpsAgentAccessPolicy` for resource discovery, and operator app role with `AIDevOpsOperatorAppAccessPolicy` for web console access
+- **Agent Space** — logical container defining the scope of AWS resources and tool integrations the agent can access; provisioned via a Lambda-backed Custom Resource
+- **AWS account association** — grants the Agent Space access to the primary account for topology discovery and CloudWatch alarm monitoring
+- **Operator App** — enables IAM-authenticated access to the DevOps Agent web console
+- **EventChannel (Webhook)** — inbound webhook endpoint for triggering investigations from external observability tools (Datadog, Grafana, PagerDuty, etc.)
+
+#### How incident response works
+
+Once deployed, AWS DevOps Agent continuously monitors your AWS environment using the associated IAM role. When a CloudWatch alarm enters ALARM state, the agent automatically initiates an investigation — no additional SNS wiring required for AWS-native alarms. It correlates metrics, logs, deployment events, and code changes across your stack to identify root cause and propose mitigation steps.
+
+For external observability tools, route alerts to the provisioned webhook URL.
+
+```
+CloudWatch Alarms  ──(IAM role polling)──▶  DevOps Agent  ──▶  Investigation
+External Tools     ──(Webhook POST)──────▶  DevOps Agent  ──▶  Investigation
+```
+
+| Resource | Description |
+| --- | --- |
+| `IAMRoleForAgentSpace` | Service role assumed by AWS DevOps Agent for resource discovery |
+| `IAMRoleForWebappAdmin` | Role for Operator App (web console) access |
+| `IAMRoleForCustomResourceLambda` | Execution role for the CloudFormation Custom Resource Lambda |
+| `ServerlessFunctionForAgentSpaceCustomResource` | Lambda that creates/updates/deletes the Agent Space via DevOps Agent API |
+| `CustomResourceForAgentSpace` | CloudFormation Custom Resource orchestrating Agent Space setup |
+| `CloudWatchAlarmForLambdaErrors` | Alarm on Custom Resource Lambda errors |
+
+| Output | Description |
+| --- | --- |
+| `AgentSpaceId` | Agent Space unique identifier |
+| `IAMRoleForAgentSpaceArn` | ARN of the DevOps Agent service role |
+| `IAMRoleForWebappAdminArn` | ARN of the Operator App role |
+| `ConsoleUrl` | Direct link to the Agent Space in the AWS DevOps Agent console |
+| `WebhookUrl` | Inbound webhook URL for external alert sources |

--- a/devops/README_JP.md
+++ b/devops/README_JP.md
@@ -1,0 +1,56 @@
+English / [**日本語**](README_JP.md)
+
+# AWSCloudFormationTemplates/devops
+![Build Status](https://codebuild.ap-northeast-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiZ3Z5MUkzdXRFcEtqM25ST0lZdW93ZVBKTnRXTk1WRGFUNkk2MzFpVERGNHp1dHU2RDNReU5IUlAvTitlRGgxNE03N3Y4ejZFaTNDVmpXdDZDK1pjRUFBPSIsIml2UGFyYW1ldGVyU3BlYyI6IllkWXQ5VVNaWE9QSnZkN3EiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
+![GitHub](https://img.shields.io/github/license/eijikominami/aws-cloudformation-templates)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/eijikominami/aws-cloudformation-templates)
+
+`AWSCloudFormationTemplates/devops` は DevOps 運用向けの **AWS フロンティア AI エージェント**をセットアップします。`AWS DevOps Agent` および自律的なインシデント対応・根本原因分析・運用改善に必要な関連リソースを含みます。
+
+## TL;DR
+
+各サービスを個別にデプロイする場合は、以下のボタンをクリックしてください。
+
+| サービス | US East（バージニア北部） | Asia Pacific（東京） |
+| --- | --- | --- |
+| AWS DevOps Agent | [![cloudformation-launch-stack](https://raw.githubusercontent.com/eijikominami/aws-cloudformation-templates/master/images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?stackName=DevOpsAgent&templateURL=https://eijikominami.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/devops/templates/devops-agent.yaml) | [![cloudformation-launch-stack](https://raw.githubusercontent.com/eijikominami/aws-cloudformation-templates/master/images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?stackName=DevOpsAgent&templateURL=https://eijikominami.s3-ap-northeast-1.amazonaws.com/aws-cloudformation-templates/devops/templates/devops-agent.yaml) |
+
+## アーキテクチャ
+
+### AWS DevOps Agent
+
+`AWS DevOps Agent` は常時稼働の**フロンティア AI エージェント**で、インシデントを自律的に解決・予防し、AWS・マルチクラウド・オンプレミス環境全体にわたってアプリケーションの信頼性を最適化し、オンデマンドの SRE タスクを処理します。
+
+このテンプレートは AWS DevOps Agent のすべての前提条件をプロビジョニングします：
+
+- **IAM ロール** — リソース発見用サービスロール（`aidevops.amazonaws.com` + `AIDevOpsAgentAccessPolicy`）と Web コンソールアクセス用 Operator App ロール（`AIDevOpsOperatorAppAccessPolicy`）
+- **Agent Space** — エージェントがアクセスできる AWS リソースとツール統合のスコープを定義する論理コンテナ。Lambda バックの Custom Resource でプロビジョニング
+- **AWS アカウント関連付け** — Agent Space にプライマリアカウントへのアクセスを付与し、トポロジー自動発見と CloudWatch アラーム監視を有効化
+- **Operator App** — IAM 認証による DevOps Agent Web コンソールへのアクセスを有効化
+- **EventChannel（Webhook）** — 外部オブザーバビリティツール（Datadog, Grafana, PagerDuty 等）からの調査トリガー用インバウンド Webhook エンドポイント
+
+#### インシデント対応の仕組み
+
+デプロイ後、AWS DevOps Agent は関連付けられた IAM ロールを使用して AWS 環境を継続的に監視します。CloudWatch アラームが ALARM 状態になると、自動的に調査を開始します（AWS ネイティブアラームに追加の SNS 設定不要）。スタック全体のメトリクス・ログ・デプロイイベント・コード変更を相関分析し、根本原因を特定して修復手順を提案します。
+
+```
+CloudWatch アラーム  ──（IAM ロールポーリング）──▶  DevOps Agent  ──▶  調査
+外部ツール          ──（Webhook POST）──────────▶  DevOps Agent  ──▶  調査
+```
+
+| リソース | 説明 |
+| --- | --- |
+| `IAMRoleForAgentSpace` | AWS DevOps Agent がリソース発見のために引き受けるサービスロール |
+| `IAMRoleForWebappAdmin` | Operator App（Web コンソール）アクセス用ロール |
+| `IAMRoleForCustomResourceLambda` | CloudFormation Custom Resource Lambda の実行ロール |
+| `ServerlessFunctionForAgentSpaceCustomResource` | DevOps Agent API 経由で Agent Space を作成・更新・削除する Lambda |
+| `CustomResourceForAgentSpace` | Agent Space セットアップを統括する CloudFormation Custom Resource |
+| `CloudWatchAlarmForLambdaErrors` | Custom Resource Lambda エラーに対するアラーム |
+
+| 出力 | 説明 |
+| --- | --- |
+| `AgentSpaceId` | Agent Space の一意識別子 |
+| `IAMRoleForAgentSpaceArn` | DevOps Agent サービスロールの ARN |
+| `IAMRoleForWebappAdminArn` | Operator App ロールの ARN |
+| `ConsoleUrl` | AWS DevOps Agent コンソールの Agent Space への直接リンク |
+| `WebhookUrl` | 外部アラートソース用インバウンド Webhook URL |

--- a/devops/templates/devops-agent.yaml
+++ b/devops/templates/devops-agent.yaml
@@ -1,0 +1,410 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Transform: AWS::Serverless-2016-10-31
+
+Description: aws-cloudformation-templates/devops/devops-agent sets AWS DevOps Agent.
+
+Globals:
+  Function:
+    Architectures:
+      - arm64
+    Handler: index.lambda_handler
+    Runtime: python3.13
+    Tracing: Active
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: 'DevOps Agent Configuration'
+        Parameters:
+          - AgentSpaceDescription
+          - AgentSpaceLocale
+          - AgentSpaceName
+      - Label:
+          default: 'Notification Configuration'
+        Parameters:
+          - AlarmLevel
+          - SNSForAlertArn
+          - SNSForDeploymentArn
+      - Label:
+          default: 'Tag Configuration'
+        Parameters:
+          - LogicalName
+          - Environment
+          - TagKey
+          - TagValue
+
+Parameters:
+  AgentSpaceDescription:
+    Type: String
+    Default: AWS DevOps Agent space for CloudWatch alarm investigation
+    Description: The description of the agent space
+
+  AgentSpaceLocale:
+    Type: String
+    Default: en
+    AllowedValues:
+      - ar
+      - de
+      - en
+      - es
+      - fr
+      - id
+      - it
+      - ja
+      - ko
+      - pt
+      - th
+      - tr
+      - vi
+      - zh-cn
+      - zh-tw
+    Description: The language for agent responses
+
+  AgentSpaceName:
+    Type: String
+    Default: devops-agent-space
+    AllowedPattern: '[a-zA-Z0-9-]{1,64}'
+    Description: The name of the AWS DevOps Agent agent space [required]
+
+  AlarmLevel:
+    Type: String
+    Default: NOTICE
+    AllowedValues:
+      - NOTICE
+      - WARNING
+    Description: The alarm level of CloudWatch alarms
+
+  Environment:
+    Type: String
+    Default: production
+    AllowedValues:
+      - production
+      - test
+      - development
+
+  LogicalName:
+    Type: String
+    Default: DevOpsAgent
+    AllowedPattern: .+
+    Description: The custom prefix name [required]
+
+  SNSForAlertArn:
+    Type: String
+    Default: ''
+    Description: The Amazon SNS topic ARN for alert
+
+  SNSForDeploymentArn:
+    Type: String
+    Default: ''
+    Description: The Amazon SNS topic ARN for deployment information
+
+  TagKey:
+    Type: String
+    Default: createdby
+    AllowedPattern: .+
+
+  TagValue:
+    Type: String
+    Default: aws-cloudformation-templates
+    AllowedPattern: .+
+
+Conditions:
+  CreateSNSForAlert: !Equals [!Ref SNSForAlertArn, '']
+  CreateSNSForDeployment: !Equals [!Ref SNSForDeploymentArn, '']
+
+Resources:
+  # Nested Stack
+  SNSForAlert:
+    Condition: CreateSNSForAlert
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 2.2.24
+      NotificationARNs:
+        - !If
+          - CreateSNSForDeployment
+          - !GetAtt SNSForDeployment.Outputs.SNSTopicArn
+          - !Ref SNSForDeploymentArn
+      Parameters:
+        TopicName: !Sub Alert-createdby-${LogicalName}
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
+
+  SNSForDeployment:
+    Condition: CreateSNSForDeployment
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-east-1:172664222583:applications/sns-topic
+        SemanticVersion: 2.2.24
+      Parameters:
+        TopicName: !Sub Deployment-createdby-${LogicalName}
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
+
+  # IAM
+  IAMRoleForAgentSpace:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub 'arn:aws:aidevops:${AWS::Region}:${AWS::AccountId}:agentspace/*'
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+            Effect: Allow
+            Principal:
+              Service: aidevops.amazonaws.com
+        Version: '2012-10-17'
+      Description: !Sub IAM role for DevOps Agent Space in ${AWS::StackName}
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - iam:CreateServiceLinkedRole
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:iam::${AWS::AccountId}:role/aws-service-role/resource-explorer-2.amazonaws.com/AWSServiceRoleForResourceExplorer'
+            Version: '2012-10-17'
+          PolicyName: AllowCreateResourceExplorerServiceLinkedRole
+      RoleName: !Sub ${LogicalName}-AgentSpace-${AWS::Region}
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+
+  IAMRoleForCustomResourceLambda:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+      Description: !Sub IAM role for DevOps Agent Custom Resource Lambda in ${AWS::StackName}
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - aidevops:AssociateService
+                  - aidevops:CreateAgentSpace
+                  - aidevops:DeleteAgentSpace
+                  - aidevops:DeregisterService
+                  - aidevops:DisableOperatorApp
+                  - aidevops:DisassociateService
+                  - aidevops:EnableOperatorApp
+                  - aidevops:RegisterService
+                  - aidevops:UpdateAgentSpace
+                Effect: Allow
+                Resource: '*'
+              - Action:
+                  - iam:PassRole
+                Effect: Allow
+                Resource:
+                  - !GetAtt IAMRoleForAgentSpace.Arn
+                  - !GetAtt IAMRoleForWebappAdmin.Arn
+            Version: '2012-10-17'
+          PolicyName: DevOpsAgentSpaceManagement
+      RoleName: !Sub ${LogicalName}-DevOpsAgent-CustomResource-${AWS::Region}
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+
+  IAMRoleForWebappAdmin:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+              - sts:TagSession
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub 'arn:aws:aidevops:${AWS::Region}:${AWS::AccountId}:agentspace/*'
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+            Effect: Allow
+            Principal:
+              Service: aidevops.amazonaws.com
+        Version: '2012-10-17'
+      Description: !Sub IAM role for DevOps Agent Operator App in ${AWS::StackName}
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy
+      RoleName: !Sub ${LogicalName}-WebappAdmin-${AWS::Region}
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: !Ref TagKey
+          Value: !Ref TagValue
+
+  # CloudWatch
+  CloudWatchAlarmForLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !If
+          - CreateSNSForAlert
+          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
+          - !Ref SNSForAlertArn
+      AlarmDescription: AWS DevOps Agent custom resource Lambda errors
+      AlarmName: !Sub ${AlarmLevel}-${LogicalName}-DevOpsAgent-Lambda-Errors
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref ServerlessFunctionForAgentSpaceCustomResource
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      OKActions:
+        - !If
+          - CreateSNSForAlert
+          - !GetAtt SNSForAlert.Outputs.SNSTopicArn
+          - !Ref SNSForAlertArn
+      Period: 60
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  # Lambda
+  ServerlessFunctionForAgentSpaceCustomResource:
+    Type: AWS::Serverless::Function
+    Properties:
+      Description: Custom Resource Lambda that creates an AWS DevOps Agent Agent Space
+      Environment:
+        Variables:
+          LOG_LEVEL: INFO
+      FunctionName: !Sub ${LogicalName}-DevOpsAgent-AgentSpace-CR
+      InlineCode: |
+        import boto3
+        import cfnresponse
+        import json
+        import logging
+
+        logger = logging.getLogger()
+        logger.setLevel(logging.INFO)
+
+        def lambda_handler(event, context):
+            logger.info(json.dumps(event))
+            request_type = event['RequestType']
+            props = event.get('ResourceProperties', {})
+            physical_id = event.get('PhysicalResourceId', 'pending')
+
+            client = boto3.client('devops-agent', region_name=props.get('Region'))
+
+            try:
+                if request_type == 'Create':
+                    space = client.create_agent_space(
+                        name=props['AgentSpaceName'],
+                        description=props.get('AgentSpaceDescription', ''),
+                        locale=props.get('AgentSpaceLocale', 'en')
+                    )
+                    agent_space_id = space['agentSpace']['agentSpaceId']
+                    client.associate_service(
+                        agentSpaceId=agent_space_id,
+                        serviceId='aws',
+                        configuration={
+                            'aws': {
+                                'assumableRoleArn': props['AgentSpaceRoleArn'],
+                                'accountId': props['AccountId'],
+                                'accountType': 'monitor'
+                            }
+                        }
+                    )
+                    client.enable_operator_app(
+                        agentSpaceId=agent_space_id,
+                        authFlow='iam',
+                        operatorAppRoleArn=props['WebappAdminRoleArn']
+                    )
+                    svc = client.register_service(
+                        service='eventChannel',
+                        serviceDetails={'eventChannel': {'type': 'webhook'}},
+                        name=props['AgentSpaceName'] + '-event-channel'
+                    )
+                    ec = client.associate_service(
+                        agentSpaceId=agent_space_id,
+                        serviceId=svc['serviceId'],
+                        configuration={'eventChannel': {}}
+                    )
+                    cfnresponse.send(event, context, cfnresponse.SUCCESS, {
+                        'AgentSpaceId': agent_space_id,
+                        'WebhookUrl': ec.get('webhook', {}).get('webhookUrl', '')
+                    }, agent_space_id)
+
+                elif request_type == 'Update':
+                    client.update_agent_space(
+                        agentSpaceId=physical_id,
+                        name=props['AgentSpaceName'],
+                        description=props.get('AgentSpaceDescription', ''),
+                        locale=props.get('AgentSpaceLocale', 'en')
+                    )
+                    cfnresponse.send(event, context, cfnresponse.SUCCESS,
+                                     {'AgentSpaceId': physical_id}, physical_id)
+
+                elif request_type == 'Delete':
+                    try:
+                        client.delete_agent_space(agentSpaceId=physical_id)
+                    except client.exceptions.ResourceNotFoundException:
+                        pass
+                    cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physical_id)
+
+            except Exception as e:
+                logger.exception('Custom resource failed')
+                cfnresponse.send(event, context, cfnresponse.FAILED,
+                                 {'Message': str(e)}, physical_id)
+      MemorySize: 128
+      Role: !GetAtt IAMRoleForCustomResourceLambda.Arn
+      Tags:
+        environment: !Ref Environment
+        createdby: !Ref TagValue
+      Timeout: 60
+
+  # Custom Resource
+  CustomResourceForAgentSpace:
+    Type: Custom::DevOpsAgentSpace
+    Properties:
+      AccountId: !Ref AWS::AccountId
+      AgentSpaceDescription: !Ref AgentSpaceDescription
+      AgentSpaceLocale: !Ref AgentSpaceLocale
+      AgentSpaceName: !Ref AgentSpaceName
+      AgentSpaceRoleArn: !GetAtt IAMRoleForAgentSpace.Arn
+      Region: !Ref AWS::Region
+      ServiceToken: !GetAtt ServerlessFunctionForAgentSpaceCustomResource.Arn
+      WebappAdminRoleArn: !GetAtt IAMRoleForWebappAdmin.Arn
+
+Outputs:
+  AgentSpaceId:
+    Description: The AWS DevOps Agent Agent Space ID
+    Value: !GetAtt CustomResourceForAgentSpace.AgentSpaceId
+
+  IAMRoleForAgentSpaceArn:
+    Description: The IAM role ARN for the DevOps Agent Space
+    Value: !GetAtt IAMRoleForAgentSpace.Arn
+
+  IAMRoleForWebappAdminArn:
+    Description: The IAM role ARN for the DevOps Agent Operator App
+    Value: !GetAtt IAMRoleForWebappAdmin.Arn
+
+  ConsoleUrl:
+    Description: The AWS DevOps Agent console URL for the Agent Space
+    Value: !Sub 'https://${AWS::Region}.console.aws.amazon.com/devops-agent/home?region=${AWS::Region}#/agentspaces/${CustomResourceForAgentSpace.AgentSpaceId}'
+
+  WebhookUrl:
+    Description: The webhook URL for the DevOps Agent EventChannel
+    Value: !GetAtt CustomResourceForAgentSpace.WebhookUrl


### PR DESCRIPTION
## Summary

Adds CloudFormation/SAM support for **AWS DevOps Agent**, an always-available frontier AI agent for autonomous incident response and operational excellence. This PR mirrors the structure introduced in #134 (AWS Security Agent) to establish a consistent pattern for frontier AI agent templates under the new `devops/` module.

## What's included

- `devops/templates/devops-agent.yaml` — SAM template provisioning all prerequisites for AWS DevOps Agent
- `devops/README.md` — English documentation
- `devops/README_JP.md` — Japanese documentation

## Resources created by the template

| Resource | Description |
|---|---|
| `IAMRoleForAgentSpace` | Service role (`aidevops.amazonaws.com`) with `AIDevOpsAgentAccessPolicy` for resource discovery and CloudWatch monitoring |
| `IAMRoleForWebappAdmin` | Operator App role with `AIDevOpsOperatorAppAccessPolicy` for web console access |
| `IAMRoleForCustomResourceLambda` | Lambda execution role with `aidevops:*` admin permissions + `iam:PassRole` |
| `ServerlessFunctionForAgentSpaceCustomResource` | Lambda Custom Resource that atomically creates the Agent Space, associates the primary AWS account, enables the Operator App, and registers the EventChannel webhook |
| `CustomResourceForAgentSpace` | CloudFormation Custom Resource orchestrating the full setup |
| `CloudWatchAlarmForLambdaErrors` | Alarm on Custom Resource Lambda errors |
| `SNSForAlert` / `SNSForDeployment` | Standard nested SNS stacks (conditional) |

## How it works

AWS DevOps Agent polls CloudWatch directly via the associated IAM role — no SNS action wiring needed for AWS-native alarms. The EventChannel webhook enables external observability tools (Datadog, Grafana, PagerDuty) to push alerts into the agent.

```
CloudWatch Alarms  ──(IAM role polling)──▶  DevOps Agent  ──▶  Autonomous Investigation
External Tools     ──(Webhook POST)──────▶  DevOps Agent  ──▶  Autonomous Investigation
```

## Checklist

- [x] cfn-lint: no errors, no warnings
- [x] Section order per guidelines (AWSTemplateFormatVersion → Transform → Description → Globals → Metadata → Parameters → Conditions → Resources → Outputs)
- [x] Parameters alphabetical
- [x] Resource names follow `ResourceTypeFor[Purpose]` pattern
- [x] Outputs ordered: IDs → ARNs → URLs
- [x] README (EN + JP)